### PR TITLE
feat: エージェント機能 Phase A 実装（ツール呼び出し基盤）

### DIFF
--- a/front/prisma/migrations/20260402000000_add_message_metadata/migration.sql
+++ b/front/prisma/migrations/20260402000000_add_message_metadata/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable: Message に metadata カラムを追加
+-- ツール呼び出し情報を格納する nullable な JSON フィールド
+ALTER TABLE "Message" ADD COLUMN "metadata" JSONB;

--- a/front/prisma/schema.prisma
+++ b/front/prisma/schema.prisma
@@ -21,5 +21,6 @@ model Message {
   conversation   Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
   role           String
   content        String
+  metadata       Json?        // ツール呼び出し情報等 { toolCalls: ToolCallRecord[] }
   createdAt      DateTime     @default(now())
 }

--- a/front/src/app/api/chat/route.ts
+++ b/front/src/app/api/chat/route.ts
@@ -1,13 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { streamChat, OllamaChatMessage, OllamaStreamChunk } from '@/lib/ollama';
 import { runAgentLoop } from '@/lib/agent';
-import { registerTool } from '@/lib/tools/index';
-import { getCurrentDatetimeTool } from '@/lib/tools/get-current-datetime';
-import { calculateTool } from '@/lib/tools/calculate';
+import { initializeTools } from '@/lib/tools/registry';
 
-// ツールを登録（モジュール初回ロード時に1度だけ実行）
-registerTool(getCurrentDatetimeTool);
-registerTool(calculateTool);
+// ツールを登録（registry.ts で一元管理）
+initializeTools();
 
 export async function POST(request: NextRequest) {
   let body: {

--- a/front/src/app/api/chat/route.ts
+++ b/front/src/app/api/chat/route.ts
@@ -1,11 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { streamChat, OllamaChatMessage, OllamaStreamChunk } from '@/lib/ollama';
+import { runAgentLoop } from '@/lib/agent';
+import { registerTool } from '@/lib/tools/index';
+import { getCurrentDatetimeTool } from '@/lib/tools/get-current-datetime';
+import { calculateTool } from '@/lib/tools/calculate';
+
+// ツールを登録（モジュール初回ロード時に1度だけ実行）
+registerTool(getCurrentDatetimeTool);
+registerTool(calculateTool);
 
 export async function POST(request: NextRequest) {
   let body: {
     message?: string;
     conversationHistory?: OllamaChatMessage[];
     model?: string;
+    enableTools?: boolean;
   };
 
   try {
@@ -17,7 +26,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const { message, conversationHistory = [], model } = body;
+  const { message, conversationHistory = [], model, enableTools = false } = body;
 
   if (!message || typeof message !== 'string' || !message.trim()) {
     return NextResponse.json({ error: 'メッセージが空です' }, { status: 400 });
@@ -34,6 +43,18 @@ export async function POST(request: NextRequest) {
     ...conversationHistory,
     { role: 'user', content: message.trim() },
   ];
+
+  // エージェントモード: NDJSON イベントストリームを返す
+  if (enableTools) {
+    const agentStream = runAgentLoop(messages, model);
+    return new Response(agentStream, {
+      headers: {
+        'Content-Type': 'application/x-ndjson',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+    });
+  }
 
   let ollamaResponse: Response;
   try {

--- a/front/src/app/api/conversations/[id]/messages/route.ts
+++ b/front/src/app/api/conversations/[id]/messages/route.ts
@@ -84,8 +84,9 @@ export async function POST(
         conversationId: id,
         role,
         content,
-        // null は Prisma の NullableJsonNullValueInput と非互換のため undefined に変換して省略
-        ...(metadata != null && { metadata }),
+        // Record<string, unknown> → unknown → any で Prisma の InputJsonValue 型制約を回避
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...(metadata != null && { metadata: metadata as unknown as any }),
       },
     });
 

--- a/front/src/app/api/conversations/[id]/messages/route.ts
+++ b/front/src/app/api/conversations/[id]/messages/route.ts
@@ -22,13 +22,6 @@ export async function GET(
     const messages = await prisma.message.findMany({
       where: { conversationId: id },
       orderBy: { createdAt: 'asc' },
-      select: {
-        id: true,
-        role: true,
-        content: true,
-        // metadata は prisma generate 後に追加
-        createdAt: true,
-      },
     });
 
     return NextResponse.json({ messages });
@@ -67,6 +60,13 @@ export async function POST(
     );
   }
 
+  if (!['user', 'assistant'].includes(role)) {
+    return NextResponse.json(
+      { error: 'roleは "user" または "assistant" のみ有効です' },
+      { status: 400 }
+    );
+  }
+
   try {
     const conversation = await prisma.conversation.findUnique({
       where: { id },
@@ -84,8 +84,7 @@ export async function POST(
         conversationId: id,
         role,
         content,
-        // metadata は prisma generate 後に有効化
-        // ...(metadata !== undefined && { metadata }),
+        ...(metadata !== undefined && { metadata }),
       },
     });
 

--- a/front/src/app/api/conversations/[id]/messages/route.ts
+++ b/front/src/app/api/conversations/[id]/messages/route.ts
@@ -26,6 +26,7 @@ export async function GET(
         id: true,
         role: true,
         content: true,
+        // metadata は prisma generate 後に追加
         createdAt: true,
       },
     });
@@ -46,7 +47,7 @@ export async function POST(
 ) {
   const { id } = await params;
 
-  let body: { role?: string; content?: string };
+  let body: { role?: string; content?: string; metadata?: Record<string, unknown> | null };
 
   try {
     body = await request.json();
@@ -57,7 +58,7 @@ export async function POST(
     );
   }
 
-  const { role, content } = body;
+  const { role, content, metadata } = body;
 
   if (!role || !content) {
     return NextResponse.json(
@@ -83,6 +84,8 @@ export async function POST(
         conversationId: id,
         role,
         content,
+        // metadata は prisma generate 後に有効化
+        // ...(metadata !== undefined && { metadata }),
       },
     });
 

--- a/front/src/app/api/conversations/[id]/messages/route.ts
+++ b/front/src/app/api/conversations/[id]/messages/route.ts
@@ -84,7 +84,8 @@ export async function POST(
         conversationId: id,
         role,
         content,
-        ...(metadata !== undefined && { metadata }),
+        // null は Prisma の NullableJsonNullValueInput と非互換のため undefined に変換して省略
+        ...(metadata != null && { metadata }),
       },
     });
 

--- a/front/src/app/api/tools/route.ts
+++ b/front/src/app/api/tools/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { getAllToolDefinitions, registerTool } from '@/lib/tools/index';
+import { getCurrentDatetimeTool } from '@/lib/tools/get-current-datetime';
+import { calculateTool } from '@/lib/tools/calculate';
+
+// ツールを登録（モジュール初回ロード時に1度だけ実行）
+registerTool(getCurrentDatetimeTool);
+registerTool(calculateTool);
+
+export async function GET() {
+  const definitions = getAllToolDefinitions();
+
+  const tools = definitions.map((def) => ({
+    name: def.function.name,
+    description: def.function.description,
+    enabled: true,
+  }));
+
+  return NextResponse.json({ tools });
+}

--- a/front/src/app/api/tools/route.ts
+++ b/front/src/app/api/tools/route.ts
@@ -1,11 +1,9 @@
 import { NextResponse } from 'next/server';
-import { getAllToolDefinitions, registerTool } from '@/lib/tools/index';
-import { getCurrentDatetimeTool } from '@/lib/tools/get-current-datetime';
-import { calculateTool } from '@/lib/tools/calculate';
+import { getAllToolDefinitions } from '@/lib/tools/index';
+import { initializeTools } from '@/lib/tools/registry';
 
-// ツールを登録（モジュール初回ロード時に1度だけ実行）
-registerTool(getCurrentDatetimeTool);
-registerTool(calculateTool);
+// ツールを登録（registry.ts で一元管理）
+initializeTools();
 
 export async function GET() {
   const definitions = getAllToolDefinitions();

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -16,7 +16,18 @@ export default function Home() {
   const [models, setModels] = useState<string[]>([]);
   const [selectedModel, setSelectedModel] = useState('');
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [enableTools, setEnableTools] = useState(false);
   const { theme, setTheme } = useTheme();
+
+  useEffect(() => {
+    const stored = localStorage.getItem('agent-tools-enabled');
+    if (stored === 'true') setEnableTools(true);
+  }, []);
+
+  const handleEnableToolsChange = useCallback((enabled: boolean) => {
+    setEnableTools(enabled);
+    localStorage.setItem('agent-tools-enabled', String(enabled));
+  }, []);
 
   useEffect(() => {
     async function fetchModels() {
@@ -58,12 +69,14 @@ export default function Home() {
     messages,
     isLoading,
     error,
+    activeToolCall,
     sendMessage,
     clearMessages,
     loadMessages,
   } = useChat({
     conversationId: currentConversationId,
     model: selectedModel,
+    enableTools,
     onConversationCreated: handleConversationCreated,
     onTitleGenerated: refreshConversations,
   });
@@ -116,7 +129,7 @@ export default function Home() {
           selectedModel={selectedModel}
           onModelChange={setSelectedModel}
         />
-        <ChatWindow messages={messages} />
+        <ChatWindow messages={messages} activeToolCall={activeToolCall} />
         {error && (
           <div className="px-4 md:px-8 py-2 bg-nord-aurora-red/20 text-nord-aurora-red text-sm text-center">
             {error}
@@ -134,6 +147,8 @@ export default function Home() {
         onModelChange={setSelectedModel}
         theme={theme}
         onThemeChange={setTheme}
+        enableTools={enableTools}
+        onEnableToolsChange={handleEnableToolsChange}
       />
     </div>
   );

--- a/front/src/components/SettingsModal.tsx
+++ b/front/src/components/SettingsModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { X, Bot, Palette } from 'lucide-react';
+import { X, Bot, Palette, Wrench } from 'lucide-react';
 import { type ThemeId, THEMES } from '@/hooks/useTheme';
 
 interface SettingsModalProps {
@@ -11,6 +11,8 @@ interface SettingsModalProps {
   onModelChange: (model: string) => void;
   theme: ThemeId;
   onThemeChange: (theme: ThemeId) => void;
+  enableTools: boolean;
+  onEnableToolsChange: (enabled: boolean) => void;
 }
 
 export default function SettingsModal({
@@ -21,6 +23,8 @@ export default function SettingsModal({
   onModelChange,
   theme,
   onThemeChange,
+  enableTools,
+  onEnableToolsChange,
 }: SettingsModalProps) {
   if (!isOpen) return null;
 
@@ -71,6 +75,39 @@ export default function SettingsModal({
             <p className="text-xs text-nord-4/60">
               Ollamaで利用可能なモデルを選択します
             </p>
+          </div>
+
+          <div className="space-y-3">
+            <label className="flex items-center gap-2 text-sm font-semibold text-nord-6">
+              <Wrench size={16} className="text-nord-frost-1" />
+              Agent Tools
+            </label>
+            <button
+              onClick={() => onEnableToolsChange(!enableTools)}
+              className={`flex items-center justify-between w-full px-4 py-3 rounded-lg border transition-all ${
+                enableTools
+                  ? 'bg-nord-frost-1/20 border-nord-frost-1'
+                  : 'bg-nord-2 border-nord-3 hover:bg-nord-3'
+              }`}
+            >
+              <div className="text-left">
+                <p className="text-sm font-semibold text-nord-6">ツール使用を有効化</p>
+                <p className="text-xs text-nord-4/60">
+                  AIが日時取得・計算などのツールを自律的に使用します
+                </p>
+              </div>
+              <div
+                className={`relative w-11 h-6 rounded-full transition-colors shrink-0 ml-4 ${
+                  enableTools ? 'bg-nord-frost-1' : 'bg-nord-3'
+                }`}
+              >
+                <div
+                  className={`absolute top-1 w-4 h-4 rounded-full bg-white shadow transition-transform ${
+                    enableTools ? 'translate-x-6' : 'translate-x-1'
+                  }`}
+                />
+              </div>
+            </button>
           </div>
 
           <div className="space-y-3">

--- a/front/src/features/chat/components/ChatWindow.tsx
+++ b/front/src/features/chat/components/ChatWindow.tsx
@@ -85,7 +85,12 @@ export default function ChatWindow({ messages, activeToolCall }: ChatWindowProps
               }`}
             >
               {msg.role === 'assistant' && (
-                <button className="hover:text-nord-frost-1 transition-colors">
+                // TODO: クリップボードコピー機能は Phase A 外。Phase B で実装予定
+                <button
+                  className="hover:text-nord-frost-1 transition-colors"
+                  onClick={() => navigator.clipboard.writeText(msg.content)}
+                  aria-label="コピー"
+                >
                   <Copy size={14} />
                 </button>
               )}

--- a/front/src/features/chat/components/ChatWindow.tsx
+++ b/front/src/features/chat/components/ChatWindow.tsx
@@ -4,12 +4,15 @@ import { useEffect, useRef } from 'react';
 import { User, Bot, Copy } from 'lucide-react';
 import { Message } from '@/types';
 import MarkdownContent from './MarkdownContent';
+import { ToolCallIndicator } from './ToolCallIndicator';
+import { ToolCallResult } from './ToolCallResult';
 
 interface ChatWindowProps {
   messages: Message[];
+  activeToolCall?: { name: string; arguments: Record<string, unknown> } | null;
 }
 
-export default function ChatWindow({ messages }: ChatWindowProps) {
+export default function ChatWindow({ messages, activeToolCall }: ChatWindowProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -36,7 +39,8 @@ export default function ChatWindow({ messages }: ChatWindowProps) {
           </p>
         </div>
       ) : (
-        messages.map((msg) => (
+        <>
+        {messages.map((msg) => (
           <div
             key={msg.id}
             className={`flex flex-col max-w-[85%] md:max-w-[70%] ${
@@ -67,6 +71,14 @@ export default function ChatWindow({ messages }: ChatWindowProps) {
               </div>
             </div>
 
+            {msg.role === 'assistant' && msg.metadata?.toolCalls && msg.metadata.toolCalls.length > 0 && (
+              <div className="mt-2 space-y-1">
+                {msg.metadata.toolCalls.map((tc, i) => (
+                  <ToolCallResult key={i} toolCall={tc} />
+                ))}
+              </div>
+            )}
+
             <div
               className={`flex items-center gap-4 mt-3 px-2 text-xs text-nord-4/60 ${
                 msg.role === 'user' ? 'justify-end' : 'justify-start'
@@ -85,7 +97,13 @@ export default function ChatWindow({ messages }: ChatWindowProps) {
               </span>
             </div>
           </div>
-        ))
+        ))}
+        {activeToolCall && (
+          <div className="mr-auto max-w-[85%] md:max-w-[70%]">
+            <ToolCallIndicator name={activeToolCall.name} arguments={activeToolCall.arguments} />
+          </div>
+        )}
+        </>
       )}
     </div>
   );

--- a/front/src/features/chat/components/ToolCallIndicator.tsx
+++ b/front/src/features/chat/components/ToolCallIndicator.tsx
@@ -5,12 +5,7 @@ interface ToolCallIndicatorProps {
   arguments: Record<string, unknown>;
 }
 
-const TOOL_LABELS: Record<string, string> = {
-  get_current_datetime: '日時を取得',
-  calculate: '計算',
-  web_search: 'Web検索',
-  url_fetch: 'URLを取得',
-};
+import { TOOL_LABELS } from '../constants/toolLabels';
 
 export function ToolCallIndicator({ name, arguments: args }: ToolCallIndicatorProps) {
   const label = TOOL_LABELS[name] ?? name;

--- a/front/src/features/chat/components/ToolCallIndicator.tsx
+++ b/front/src/features/chat/components/ToolCallIndicator.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+interface ToolCallIndicatorProps {
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+const TOOL_LABELS: Record<string, string> = {
+  get_current_datetime: '日時を取得',
+  calculate: '計算',
+  web_search: 'Web検索',
+  url_fetch: 'URLを取得',
+};
+
+export function ToolCallIndicator({ name, arguments: args }: ToolCallIndicatorProps) {
+  const label = TOOL_LABELS[name] ?? name;
+  const argsSummary = Object.entries(args)
+    .map(([k, v]) => `${k}: ${String(v).slice(0, 40)}`)
+    .join(', ');
+
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-[var(--color-nord-3)] bg-[var(--color-nord-1)] px-3 py-2 text-sm text-[var(--color-nord-4)]">
+      {/* スピナー */}
+      <svg
+        className="h-4 w-4 animate-spin text-[var(--color-nord-8)]"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+        />
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+        />
+      </svg>
+      <span className="font-medium text-[var(--color-nord-8)]">🔧 {label}</span>
+      {argsSummary && (
+        <span className="truncate text-[var(--color-nord-4)] opacity-70">
+          ({argsSummary})
+        </span>
+      )}
+      <span className="ml-auto text-xs opacity-50">実行中...</span>
+    </div>
+  );
+}

--- a/front/src/features/chat/components/ToolCallResult.tsx
+++ b/front/src/features/chat/components/ToolCallResult.tsx
@@ -2,17 +2,11 @@
 
 import { useState } from 'react';
 import { ToolCallInfo } from '@/types';
+import { TOOL_LABELS } from '../constants/toolLabels';
 
 interface ToolCallResultProps {
   toolCall: ToolCallInfo;
 }
-
-const TOOL_LABELS: Record<string, string> = {
-  get_current_datetime: '日時を取得',
-  calculate: '計算',
-  web_search: 'Web検索',
-  url_fetch: 'URLを取得',
-};
 
 export function ToolCallResult({ toolCall }: ToolCallResultProps) {
   const [isExpanded, setIsExpanded] = useState(false);

--- a/front/src/features/chat/components/ToolCallResult.tsx
+++ b/front/src/features/chat/components/ToolCallResult.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState } from 'react';
+import { ToolCallInfo } from '@/types';
+
+interface ToolCallResultProps {
+  toolCall: ToolCallInfo;
+}
+
+const TOOL_LABELS: Record<string, string> = {
+  get_current_datetime: '日時を取得',
+  calculate: '計算',
+  web_search: 'Web検索',
+  url_fetch: 'URLを取得',
+};
+
+export function ToolCallResult({ toolCall }: ToolCallResultProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const label = TOOL_LABELS[toolCall.name] ?? toolCall.name;
+  const durationText = toolCall.durationMs > 0 ? `${toolCall.durationMs}ms` : null;
+
+  return (
+    <div className="rounded-md border border-[var(--color-nord-3)] bg-[var(--color-nord-1)] text-sm">
+      <button
+        onClick={() => setIsExpanded((prev) => !prev)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-[var(--color-nord-2)] transition-colors"
+      >
+        {toolCall.isError ? (
+          <span className="text-red-400">❌</span>
+        ) : (
+          <span className="text-green-400">✅</span>
+        )}
+        <span className="font-medium text-[var(--color-nord-8)]">🔧 {label}</span>
+        {durationText && (
+          <span className="text-[var(--color-nord-4)] opacity-50 text-xs">({durationText})</span>
+        )}
+        <span className="ml-auto text-[var(--color-nord-4)] opacity-50 text-xs">
+          {isExpanded ? '▲' : '▼'}
+        </span>
+      </button>
+
+      {isExpanded && (
+        <div className="border-t border-[var(--color-nord-3)] px-3 py-2 space-y-2">
+          {Object.keys(toolCall.arguments).length > 0 && (
+            <div>
+              <p className="text-xs text-[var(--color-nord-4)] opacity-60 mb-1">引数</p>
+              <pre className="text-xs text-[var(--color-nord-4)] whitespace-pre-wrap break-all">
+                {JSON.stringify(toolCall.arguments, null, 2)}
+              </pre>
+            </div>
+          )}
+          <div>
+            <p className="text-xs text-[var(--color-nord-4)] opacity-60 mb-1">結果</p>
+            <pre
+              className={`text-xs whitespace-pre-wrap break-all ${
+                toolCall.isError ? 'text-red-400' : 'text-[var(--color-nord-4)]'
+              }`}
+            >
+              {toolCall.result || '(空の結果)'}
+            </pre>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/src/features/chat/constants/toolLabels.ts
+++ b/front/src/features/chat/constants/toolLabels.ts
@@ -1,0 +1,6 @@
+export const TOOL_LABELS: Record<string, string> = {
+  get_current_datetime: '日時を取得',
+  calculate: '計算',
+  web_search: 'Web検索',
+  url_fetch: 'URLを取得',
+};

--- a/front/src/features/chat/hooks/useChat.ts
+++ b/front/src/features/chat/hooks/useChat.ts
@@ -120,6 +120,9 @@ export function useChat({
 
       let fullAiContent = '';
       const toolCallRecords: ToolCallInfo[] = [];
+      // tool_call_start で受け取った arguments を tool_call_result まで保持する
+      // 同名ツールが複数回呼ばれる場合に備え、FIFO キューで管理
+      const pendingToolArgs = new Map<string, Array<Record<string, unknown>>>();
 
       try {
         const response = await fetch('/api/chat', {
@@ -177,6 +180,10 @@ export function useChat({
                   );
                 } else if (event.type === 'tool_call_start') {
                   setActiveToolCall({ name: event.name, arguments: event.arguments });
+                  // arguments を pending キューに積む
+                  const queue = pendingToolArgs.get(event.name) ?? [];
+                  queue.push(event.arguments);
+                  pendingToolArgs.set(event.name, queue);
                   // ツール実行中を UI に反映
                   setMessages((prev) =>
                     prev.map((msg) =>
@@ -202,10 +209,17 @@ export function useChat({
                   );
                 } else if (event.type === 'tool_call_result') {
                   setActiveToolCall(null);
+                  // pending キューから先頭の arguments を取り出す（FIFO）
+                  const argsQueue = pendingToolArgs.get(event.name) ?? [];
+                  const resolvedArgs = argsQueue.shift() ?? {};
+                  if (argsQueue.length === 0) {
+                    pendingToolArgs.delete(event.name);
+                  } else {
+                    pendingToolArgs.set(event.name, argsQueue);
+                  }
                   const record: ToolCallInfo = {
                     name: event.name,
-                    arguments:
-                      toolCallRecords.find((r) => r.name === event.name)?.arguments ?? {},
+                    arguments: resolvedArgs,
                     result: event.result,
                     isError: event.isError,
                     durationMs: 0,

--- a/front/src/features/chat/hooks/useChat.ts
+++ b/front/src/features/chat/hooks/useChat.ts
@@ -1,11 +1,13 @@
 'use client';
 
 import { useState, useCallback, useRef } from 'react';
-import { Message } from '@/types';
+import { Message, ToolCallInfo } from '@/types';
+import type { AgentStreamEvent } from '@/lib/tools/types';
 
 interface UseChatOptions {
   conversationId: string | null;
   model: string;
+  enableTools?: boolean;
   onConversationCreated?: (id: string) => void;
   onTitleGenerated?: () => void;
 }
@@ -13,24 +15,30 @@ interface UseChatOptions {
 async function saveMessage(
   conversationId: string,
   role: string,
-  content: string
+  content: string,
+  metadata?: { toolCalls?: ToolCallInfo[] } | null
 ) {
   await fetch(`/api/conversations/${conversationId}/messages`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ role, content }),
+    body: JSON.stringify({ role, content, metadata }),
   });
 }
 
 export function useChat({
   conversationId,
   model,
+  enableTools = false,
   onConversationCreated,
   onTitleGenerated,
 }: UseChatOptions) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [activeToolCall, setActiveToolCall] = useState<{
+    name: string;
+    arguments: Record<string, unknown>;
+  } | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const loadMessages = useCallback(async (convId: string) => {
@@ -44,6 +52,7 @@ export function useChat({
             id: string;
             role: string;
             content: string;
+            metadata?: { toolCalls?: ToolCallInfo[] } | null;
             createdAt: string;
           }) => ({
             ...msg,
@@ -60,6 +69,7 @@ export function useChat({
     async (content: string) => {
       setError(null);
       setIsLoading(true);
+      setActiveToolCall(null);
 
       let activeConversationId: string = conversationId || '';
       const isNewConversation = !activeConversationId;
@@ -69,18 +79,14 @@ export function useChat({
           const res = await fetch('/api/conversations', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              title: content.slice(0, 100),
-            }),
+            body: JSON.stringify({ title: content.slice(0, 100) }),
           });
           if (!res.ok) throw new Error('会話の作成に失敗しました');
           const conv = await res.json();
           activeConversationId = conv.id;
           onConversationCreated?.(conv.id);
         } catch (err) {
-          const errorMessage =
-            err instanceof Error ? err.message : '会話の作成に失敗しました';
-          setError(errorMessage);
+          setError(err instanceof Error ? err.message : '会話の作成に失敗しました');
           setIsLoading(false);
           return;
         }
@@ -103,9 +109,7 @@ export function useChat({
 
       setMessages((prev) => [...prev, userMessage, aiMessage]);
 
-      await saveMessage(activeConversationId, 'user', content).catch(
-        console.error
-      );
+      await saveMessage(activeConversationId, 'user', content).catch(console.error);
 
       const conversationHistory = messages.map((msg) => ({
         role: msg.role as 'user' | 'assistant',
@@ -115,6 +119,7 @@ export function useChat({
       abortControllerRef.current = new AbortController();
 
       let fullAiContent = '';
+      const toolCallRecords: ToolCallInfo[] = [];
 
       try {
         const response = await fetch('/api/chat', {
@@ -124,6 +129,7 @@ export function useChat({
             message: content,
             conversationHistory,
             model,
+            enableTools,
           }),
           signal: abortControllerRef.current.signal,
         });
@@ -135,33 +141,144 @@ export function useChat({
           );
         }
 
-        if (!response.body) {
-          throw new Error('レスポンスが空です');
-        }
+        if (!response.body) throw new Error('レスポンスが空です');
+
+        const contentType = response.headers.get('Content-Type') ?? '';
+        const isNdjson = contentType.includes('application/x-ndjson');
 
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
 
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
+        if (isNdjson) {
+          // --- エージェントモード: NDJSON イベントストリーム ---
+          let lineBuffer = '';
 
-          const text = decoder.decode(value, { stream: true });
-          fullAiContent += text;
-          setMessages((prev) =>
-            prev.map((msg) =>
-              msg.id === aiMessageId
-                ? { ...msg, content: msg.content + text }
-                : msg
-            )
-          );
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            lineBuffer += decoder.decode(value, { stream: true });
+            const lines = lineBuffer.split('\n');
+            lineBuffer = lines.pop() ?? '';
+
+            for (const line of lines) {
+              if (!line.trim()) continue;
+              try {
+                const event: AgentStreamEvent = JSON.parse(line);
+
+                if (event.type === 'text_delta') {
+                  fullAiContent += event.content;
+                  setMessages((prev) =>
+                    prev.map((msg) =>
+                      msg.id === aiMessageId
+                        ? { ...msg, content: msg.content + event.content }
+                        : msg
+                    )
+                  );
+                } else if (event.type === 'tool_call_start') {
+                  setActiveToolCall({ name: event.name, arguments: event.arguments });
+                  // ツール実行中を UI に反映
+                  setMessages((prev) =>
+                    prev.map((msg) =>
+                      msg.id === aiMessageId
+                        ? {
+                            ...msg,
+                            metadata: {
+                              ...msg.metadata,
+                              toolCalls: [
+                                ...(msg.metadata?.toolCalls ?? []),
+                                {
+                                  name: event.name,
+                                  arguments: event.arguments,
+                                  result: '',
+                                  isError: false,
+                                  durationMs: 0,
+                                },
+                              ],
+                            },
+                          }
+                        : msg
+                    )
+                  );
+                } else if (event.type === 'tool_call_result') {
+                  setActiveToolCall(null);
+                  const record: ToolCallInfo = {
+                    name: event.name,
+                    arguments:
+                      toolCallRecords.find((r) => r.name === event.name)?.arguments ?? {},
+                    result: event.result,
+                    isError: event.isError,
+                    durationMs: 0,
+                  };
+                  toolCallRecords.push(record);
+                  // 最後のツール呼び出しレコードを結果で更新
+                  setMessages((prev) =>
+                    prev.map((msg) => {
+                      if (msg.id !== aiMessageId) return msg;
+                      const toolCalls = [...(msg.metadata?.toolCalls ?? [])];
+                      const idx = toolCalls.map((t) => t.name).lastIndexOf(event.name);
+                      if (idx >= 0) {
+                        toolCalls[idx] = {
+                          ...toolCalls[idx],
+                          result: event.result,
+                          isError: event.isError,
+                        };
+                      }
+                      return { ...msg, metadata: { toolCalls } };
+                    })
+                  );
+                } else if (event.type === 'done') {
+                  if (event.metadata?.toolCalls) {
+                    // durationMs を done イベントの値で更新
+                    setMessages((prev) =>
+                      prev.map((msg) =>
+                        msg.id === aiMessageId
+                          ? {
+                              ...msg,
+                              metadata: { toolCalls: event.metadata!.toolCalls },
+                            }
+                          : msg
+                      )
+                    );
+                    toolCallRecords.length = 0;
+                    toolCallRecords.push(...event.metadata.toolCalls);
+                  }
+                } else if (event.type === 'error') {
+                  throw new Error(event.message);
+                }
+              } catch (parseErr) {
+                // JSON パース失敗は無視（不完全な行等）
+                if (parseErr instanceof SyntaxError) continue;
+                throw parseErr;
+              }
+            }
+          }
+        } else {
+          // --- 通常モード: プレーンテキストストリーミング（後方互換） ---
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            const text = decoder.decode(value, { stream: true });
+            fullAiContent += text;
+            setMessages((prev) =>
+              prev.map((msg) =>
+                msg.id === aiMessageId
+                  ? { ...msg, content: msg.content + text }
+                  : msg
+              )
+            );
+          }
         }
 
         if (fullAiContent) {
+          const metadata =
+            toolCallRecords.length > 0 ? { toolCalls: toolCallRecords } : null;
           await saveMessage(
             activeConversationId,
             'assistant',
-            fullAiContent
+            fullAiContent,
+            metadata
           ).catch(console.error);
 
           if (isNewConversation) {
@@ -175,30 +292,29 @@ export function useChat({
           }
         }
       } catch (err) {
-        if (err instanceof DOMException && err.name === 'AbortError') {
-          return;
-        }
-        const errorMessage =
-          err instanceof Error ? err.message : '不明なエラーが発生しました';
-        setError(errorMessage);
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        setError(err instanceof Error ? err.message : '不明なエラーが発生しました');
         setMessages((prev) => prev.filter((msg) => msg.id !== aiMessageId));
       } finally {
         setIsLoading(false);
+        setActiveToolCall(null);
         abortControllerRef.current = null;
       }
     },
-    [conversationId, model, messages, onConversationCreated, onTitleGenerated]
+    [conversationId, model, enableTools, messages, onConversationCreated, onTitleGenerated]
   );
 
   const clearMessages = useCallback(() => {
     setMessages([]);
     setError(null);
+    setActiveToolCall(null);
   }, []);
 
   return {
     messages,
     isLoading,
     error,
+    activeToolCall,
     sendMessage,
     clearMessages,
     loadMessages,

--- a/front/src/features/sidebar/components/Sidebar.tsx
+++ b/front/src/features/sidebar/components/Sidebar.tsx
@@ -96,6 +96,7 @@ export default function Sidebar({
         <div className="flex gap-2 justify-center">
           <button
             onClick={onOpenSettings}
+            aria-label="設定を開く"
             className="p-2 rounded-lg text-nord-4/60 hover:bg-white/5 transition-colors"
           >
             <Settings size={20} />

--- a/front/src/lib/agent.ts
+++ b/front/src/lib/agent.ts
@@ -17,66 +17,69 @@ async function runTool(
 ): Promise<{ result: string; isError: boolean; durationMs: number }> {
   const start = Date.now();
 
-  const timeoutPromise = new Promise<never>((_, reject) =>
-    setTimeout(
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(
       () => reject(new Error(`ツール "${name}" がタイムアウトしました (${TOOL_TIMEOUT_MS}ms)`)),
       TOOL_TIMEOUT_MS
-    )
-  );
+    );
+  });
 
   try {
     const result = await Promise.race([executeTool(name, args), timeoutPromise]);
+    clearTimeout(timeoutId);
     return { result, isError: false, durationMs: Date.now() - start };
   } catch (e) {
+    clearTimeout(timeoutId);
     const msg = e instanceof Error ? e.message : String(e);
     return { result: msg, isError: true, durationMs: Date.now() - start };
   }
 }
 
-// Ollama のストリーミングレスポンスを読み取り、tool_calls かテキストかを判定する
-async function readOllamaResponse(response: Response): Promise<{
-  toolCalls: OllamaToolCall[];
-  textStream: ReadableStream<Uint8Array> | null;
-  thinkingText: string;
-}> {
+// Ollama のストリーミングレスポンスを読み取り、tool_calls かテキストかを判定する。
+// Ollama は tool_calls がある場合、done=true のチャンクに tool_calls を含めて返す。
+// テキスト応答の場合は各チャンクを逐次ストリームに流してリアルタイム表示を維持する。
+async function readOllamaResponse(
+  response: Response,
+  onTextChunk: (text: string) => void,
+  onThinking: (text: string) => void
+): Promise<{ toolCalls: OllamaToolCall[] }> {
   if (!response.body) {
     throw new Error('Ollama からのレスポンスが空です');
   }
 
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
-  let buffer = '';
+  let lineBuffer = '';
   const toolCalls: OllamaToolCall[] = [];
-  let thinkingText = '';
-
-  // ツール呼び出しか判定するために全チャンクを先読みする
-  const chunks: OllamaStreamChunk[] = [];
 
   while (true) {
     const { done, value } = await reader.read();
     if (done) break;
 
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split('\n');
-    buffer = lines.pop() ?? '';
+    lineBuffer += decoder.decode(value, { stream: true });
+    const lines = lineBuffer.split('\n');
+    lineBuffer = lines.pop() ?? '';
 
     for (const line of lines) {
       if (!line.trim()) continue;
       try {
         const chunk: OllamaStreamChunk = JSON.parse(line);
-        chunks.push(chunk);
 
-        // tool_calls を収集
+        // tool_calls を収集（通常は done=true のチャンクに含まれる）
         if (chunk.message?.tool_calls) {
           toolCalls.push(...chunk.message.tool_calls);
         }
 
-        // thinking テキストを収集（<think> タグ内、または tool_calls 前のテキスト）
         if (chunk.message?.content && !chunk.message.tool_calls) {
           const content = chunk.message.content;
+          // <think> タグ内は thinking イベントとして分離
           const thinkMatch = content.match(/<think>([\s\S]*?)<\/think>/);
           if (thinkMatch) {
-            thinkingText += thinkMatch[1];
+            onThinking(thinkMatch[1]);
+          } else {
+            // テキストチャンクをリアルタイムに通知（バッファせず即時）
+            onTextChunk(content);
           }
         }
       } catch {
@@ -85,24 +88,7 @@ async function readOllamaResponse(response: Response): Promise<{
     }
   }
 
-  // tool_calls があった場合はテキストストリームなし
-  if (toolCalls.length > 0) {
-    return { toolCalls, textStream: null, thinkingText };
-  }
-
-  // テキスト応答の場合: 収集済みチャンクを ReadableStream に変換して返す
-  const textStream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      for (const chunk of chunks) {
-        if (chunk.message?.content) {
-          controller.enqueue(new TextEncoder().encode(chunk.message.content));
-        }
-      }
-      controller.close();
-    },
-  });
-
-  return { toolCalls: [], textStream, thinkingText };
+  return { toolCalls };
 }
 
 // エージェントループのメイン関数
@@ -133,30 +119,23 @@ export function runAgentLoop(
             return;
           }
 
-          const { toolCalls, textStream, thinkingText } =
-            await readOllamaResponse(ollamaResponse);
-
-          // thinking テキストがあれば送信
-          if (thinkingText.trim()) {
-            controller.enqueue(
-              encodeEvent({ type: 'thinking', content: thinkingText.trim() })
-            );
-          }
-
-          // ツール呼び出しなし → テキスト応答をストリーミングして完了
-          if (toolCalls.length === 0) {
-            if (textStream) {
-              const reader = textStream.getReader();
-              const decoder = new TextDecoder();
-              while (true) {
-                const { done, value } = await reader.read();
-                if (done) break;
-                const text = decoder.decode(value);
-                if (text) {
-                  controller.enqueue(encodeEvent({ type: 'text_delta', content: text }));
-                }
+          const { toolCalls } = await readOllamaResponse(
+            ollamaResponse,
+            (text) => {
+              // テキストチャンクをリアルタイムに送信（バッファなし）
+              if (text) {
+                controller.enqueue(encodeEvent({ type: 'text_delta', content: text }));
+              }
+            },
+            (thinking) => {
+              if (thinking.trim()) {
+                controller.enqueue(encodeEvent({ type: 'thinking', content: thinking.trim() }));
               }
             }
+          );
+
+          // ツール呼び出しなし → テキスト応答のストリーミングは上記コールバックで完了済み
+          if (toolCalls.length === 0) {
             // 完了イベント（ツール呼び出し記録付き）
             controller.enqueue(
               encodeEvent({

--- a/front/src/lib/agent.ts
+++ b/front/src/lib/agent.ts
@@ -1,0 +1,231 @@
+import { streamChat, OllamaChatMessage, OllamaStreamChunk } from './ollama';
+import { getAllToolDefinitions, executeTool } from './tools/index';
+import type { AgentStreamEvent, ToolCallRecord, OllamaToolCall } from './tools/types';
+
+const MAX_TOOL_ROUNDS = parseInt(process.env.AGENT_MAX_TOOL_ROUNDS ?? '10', 10);
+const TOOL_TIMEOUT_MS = parseInt(process.env.AGENT_TOOL_TIMEOUT_MS ?? '30000', 10);
+
+// NDJSON イベントを ReadableStream に書き込むヘルパー
+function encodeEvent(event: AgentStreamEvent): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(event) + '\n');
+}
+
+// ツール実行（タイムアウト付き、全体タイムアウトはリトライ含む合計に適用）
+async function runTool(
+  name: string,
+  args: Record<string, unknown>
+): Promise<{ result: string; isError: boolean; durationMs: number }> {
+  const start = Date.now();
+
+  const timeoutPromise = new Promise<never>((_, reject) =>
+    setTimeout(
+      () => reject(new Error(`ツール "${name}" がタイムアウトしました (${TOOL_TIMEOUT_MS}ms)`)),
+      TOOL_TIMEOUT_MS
+    )
+  );
+
+  try {
+    const result = await Promise.race([executeTool(name, args), timeoutPromise]);
+    return { result, isError: false, durationMs: Date.now() - start };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { result: msg, isError: true, durationMs: Date.now() - start };
+  }
+}
+
+// Ollama のストリーミングレスポンスを読み取り、tool_calls かテキストかを判定する
+async function readOllamaResponse(response: Response): Promise<{
+  toolCalls: OllamaToolCall[];
+  textStream: ReadableStream<Uint8Array> | null;
+  thinkingText: string;
+}> {
+  if (!response.body) {
+    throw new Error('Ollama からのレスポンスが空です');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  const toolCalls: OllamaToolCall[] = [];
+  let thinkingText = '';
+
+  // ツール呼び出しか判定するために全チャンクを先読みする
+  const chunks: OllamaStreamChunk[] = [];
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const chunk: OllamaStreamChunk = JSON.parse(line);
+        chunks.push(chunk);
+
+        // tool_calls を収集
+        if (chunk.message?.tool_calls) {
+          toolCalls.push(...chunk.message.tool_calls);
+        }
+
+        // thinking テキストを収集（<think> タグ内、または tool_calls 前のテキスト）
+        if (chunk.message?.content && !chunk.message.tool_calls) {
+          const content = chunk.message.content;
+          const thinkMatch = content.match(/<think>([\s\S]*?)<\/think>/);
+          if (thinkMatch) {
+            thinkingText += thinkMatch[1];
+          }
+        }
+      } catch {
+        // JSONパース失敗は無視
+      }
+    }
+  }
+
+  // tool_calls があった場合はテキストストリームなし
+  if (toolCalls.length > 0) {
+    return { toolCalls, textStream: null, thinkingText };
+  }
+
+  // テキスト応答の場合: 収集済みチャンクを ReadableStream に変換して返す
+  const textStream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        if (chunk.message?.content) {
+          controller.enqueue(new TextEncoder().encode(chunk.message.content));
+        }
+      }
+      controller.close();
+    },
+  });
+
+  return { toolCalls: [], textStream, thinkingText };
+}
+
+// エージェントループのメイン関数
+// enableTools: true のときに呼び出す。NDJSON イベントストリームを返す。
+export function runAgentLoop(
+  messages: OllamaChatMessage[],
+  model?: string
+): ReadableStream<Uint8Array> {
+  const tools = getAllToolDefinitions();
+  const toolCallRecords: ToolCallRecord[] = [];
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      // メッセージ履歴のコピー（ループ内で更新する）
+      const history: OllamaChatMessage[] = [...messages];
+
+      try {
+        for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+          let ollamaResponse: Response;
+          try {
+            ollamaResponse = await streamChat(history, model, tools);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            controller.enqueue(
+              encodeEvent({ type: 'error', message: `Ollamaへの接続に失敗しました: ${msg}` })
+            );
+            controller.close();
+            return;
+          }
+
+          const { toolCalls, textStream, thinkingText } =
+            await readOllamaResponse(ollamaResponse);
+
+          // thinking テキストがあれば送信
+          if (thinkingText.trim()) {
+            controller.enqueue(
+              encodeEvent({ type: 'thinking', content: thinkingText.trim() })
+            );
+          }
+
+          // ツール呼び出しなし → テキスト応答をストリーミングして完了
+          if (toolCalls.length === 0) {
+            if (textStream) {
+              const reader = textStream.getReader();
+              const decoder = new TextDecoder();
+              while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                const text = decoder.decode(value);
+                if (text) {
+                  controller.enqueue(encodeEvent({ type: 'text_delta', content: text }));
+                }
+              }
+            }
+            // 完了イベント（ツール呼び出し記録付き）
+            controller.enqueue(
+              encodeEvent({
+                type: 'done',
+                metadata: toolCallRecords.length > 0 ? { toolCalls: toolCallRecords } : undefined,
+              })
+            );
+            controller.close();
+            return;
+          }
+
+          // ツール呼び出しあり → assistant メッセージを履歴に追加
+          history.push({
+            role: 'assistant',
+            content: '',
+            tool_calls: toolCalls,
+          });
+
+          // 複数ツールを Promise.allSettled で並列実行
+          const toolResults = await Promise.allSettled(
+            toolCalls.map(async (tc) => {
+              const name = tc.function.name;
+              const args = tc.function.arguments;
+
+              // 実行開始イベント
+              controller.enqueue(
+                encodeEvent({ type: 'tool_call_start', name, arguments: args })
+              );
+
+              const { result, isError, durationMs } = await runTool(name, args);
+
+              // 実行結果イベント
+              controller.enqueue(
+                encodeEvent({ type: 'tool_call_result', name, result, isError })
+              );
+
+              toolCallRecords.push({ name, arguments: args, result, isError, durationMs });
+
+              return { name, result };
+            })
+          );
+
+          // tool ロールのメッセージを呼び出し順で履歴に追加
+          for (let i = 0; i < toolCalls.length; i++) {
+            const settled = toolResults[i];
+            const result =
+              settled.status === 'fulfilled'
+                ? settled.value.result
+                : settled.reason instanceof Error
+                  ? settled.reason.message
+                  : String(settled.reason);
+
+            history.push({ role: 'tool', content: result });
+          }
+        }
+
+        // 最大ラウンド数超過
+        controller.enqueue(
+          encodeEvent({
+            type: 'error',
+            message: `ツール呼び出しが最大ラウンド数(${MAX_TOOL_ROUNDS})を超えました`,
+          })
+        );
+        controller.close();
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        controller.enqueue(encodeEvent({ type: 'error', message: msg }));
+        controller.close();
+      }
+    },
+  });
+}

--- a/front/src/lib/ollama.ts
+++ b/front/src/lib/ollama.ts
@@ -1,14 +1,22 @@
 const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
-const OLLAMA_DEFAULT_MODEL = process.env.OLLAMA_MODEL || 'qwen3-coder:latest';
+const OLLAMA_DEFAULT_MODEL =
+  process.env.OLLAMA_MODEL || 'qwen3-coder-next:latest';
+
+import type { OllamaToolDefinition, OllamaToolCall } from './tools/types';
 
 export interface OllamaChatMessage {
-  role: 'user' | 'assistant';
+  role: 'user' | 'assistant' | 'tool';
   content: string;
+  tool_calls?: OllamaToolCall[]; // assistant がツール呼び出しを要求するとき
 }
 
 export interface OllamaStreamChunk {
   model: string;
-  message: { role: string; content: string };
+  message: {
+    role: string;
+    content: string;
+    tool_calls?: OllamaToolCall[];
+  };
   done: boolean;
 }
 
@@ -36,16 +44,22 @@ export function getDefaultModel(): string {
 
 export async function streamChat(
   messages: OllamaChatMessage[],
-  model?: string
+  model?: string,
+  tools?: OllamaToolDefinition[]
 ): Promise<Response> {
+  const body: Record<string, unknown> = {
+    model: model || OLLAMA_DEFAULT_MODEL,
+    messages,
+    stream: true,
+  };
+  if (tools && tools.length > 0) {
+    body.tools = tools;
+  }
+
   const response = await fetch(`${OLLAMA_BASE_URL}/api/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      model: model || OLLAMA_DEFAULT_MODEL,
-      messages,
-      stream: true,
-    }),
+    body: JSON.stringify(body),
   });
 
   if (!response.ok) {

--- a/front/src/lib/tools/calculate.ts
+++ b/front/src/lib/tools/calculate.ts
@@ -49,10 +49,12 @@ export const calculateTool: Tool = {
 //   term       = factor (('*' | '/') factor)*
 //   factor     = '-' factor | '(' expression ')' | number
 
-type Parser = { input: string; pos: number };
+const MAX_RECURSION_DEPTH = 200;
+
+type Parser = { input: string; pos: number; depth: number };
 
 function parseExpression(input: string): number {
-  const p: Parser = { input, pos: 0 };
+  const p: Parser = { input, pos: 0, depth: 0 };
   const result = parseExpr(p);
   if (p.pos !== p.input.length) {
     throw new Error('計算式の形式が正しくありません');
@@ -95,10 +97,17 @@ function parseFactor(p: Parser): number {
     throw new Error('計算式が不完全です');
   }
 
+  p.depth++;
+  if (p.depth > MAX_RECURSION_DEPTH) {
+    throw new Error('計算式が複雑すぎます');
+  }
+
   // 単項マイナス
   if (p.input[p.pos] === '-') {
     p.pos++;
-    return -parseFactor(p);
+    const val = -parseFactor(p);
+    p.depth--;
+    return val;
   }
 
   // 括弧
@@ -109,11 +118,14 @@ function parseFactor(p: Parser): number {
       throw new Error('括弧が閉じられていません');
     }
     p.pos++; // ')' を消費
+    p.depth--;
     return result;
   }
 
   // 数値
-  return parseNumber(p);
+  const num = parseNumber(p);
+  p.depth--;
+  return num;
 }
 
 function parseNumber(p: Parser): number {

--- a/front/src/lib/tools/calculate.ts
+++ b/front/src/lib/tools/calculate.ts
@@ -1,0 +1,136 @@
+import { Tool } from './types';
+
+export const calculateTool: Tool = {
+  definition: {
+    name: 'calculate',
+    description: '数式を計算して結果を返す。四則演算と括弧に対応',
+    parameters: {
+      type: 'object',
+      properties: {
+        expression: {
+          type: 'string',
+          description: '計算式 (例: 2 + 3 * 4, (10 - 2) / 4)',
+        },
+      },
+      required: ['expression'],
+    },
+  },
+  execute: async (args) => {
+    const expression = typeof args.expression === 'string' ? args.expression : '';
+
+    if (!expression.trim()) {
+      return 'エラー: 計算式が空です';
+    }
+
+    // 前処理: 許可する文字のみかチェック（数字、四則演算子、括弧、小数点、空白）
+    if (!/^[\d\s+\-*/().]+$/.test(expression)) {
+      return 'エラー: 使用できない文字が含まれています。数字と四則演算子(+ - * /)と括弧のみ使用できます';
+    }
+
+    try {
+      const result = parseExpression(expression.replace(/\s/g, ''));
+      if (!isFinite(result)) {
+        return 'エラー: 計算結果が不正です（ゼロ除算等）';
+      }
+      // 浮動小数点の誤差を考慮して適切な精度で返す
+      const formatted =
+        Number.isInteger(result) ? String(result) : String(parseFloat(result.toPrecision(12)));
+      return `${expression.trim()} = ${formatted}`;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : '不明なエラー';
+      return `エラー: ${msg}`;
+    }
+  },
+};
+
+// 再帰下降パーサー
+// 文法:
+//   expression = term (('+' | '-') term)*
+//   term       = factor (('*' | '/') factor)*
+//   factor     = '-' factor | '(' expression ')' | number
+
+type Parser = { input: string; pos: number };
+
+function parseExpression(input: string): number {
+  const p: Parser = { input, pos: 0 };
+  const result = parseExpr(p);
+  if (p.pos !== p.input.length) {
+    throw new Error('計算式の形式が正しくありません');
+  }
+  return result;
+}
+
+function parseExpr(p: Parser): number {
+  let left = parseTerm(p);
+  while (p.pos < p.input.length) {
+    const ch = p.input[p.pos];
+    if (ch === '+' || ch === '-') {
+      p.pos++;
+      const right = parseTerm(p);
+      left = ch === '+' ? left + right : left - right;
+    } else {
+      break;
+    }
+  }
+  return left;
+}
+
+function parseTerm(p: Parser): number {
+  let left = parseFactor(p);
+  while (p.pos < p.input.length) {
+    const ch = p.input[p.pos];
+    if (ch === '*' || ch === '/') {
+      p.pos++;
+      const right = parseFactor(p);
+      left = ch === '*' ? left * right : left / right;
+    } else {
+      break;
+    }
+  }
+  return left;
+}
+
+function parseFactor(p: Parser): number {
+  if (p.pos >= p.input.length) {
+    throw new Error('計算式が不完全です');
+  }
+
+  // 単項マイナス
+  if (p.input[p.pos] === '-') {
+    p.pos++;
+    return -parseFactor(p);
+  }
+
+  // 括弧
+  if (p.input[p.pos] === '(') {
+    p.pos++; // '(' を消費
+    const result = parseExpr(p);
+    if (p.pos >= p.input.length || p.input[p.pos] !== ')') {
+      throw new Error('括弧が閉じられていません');
+    }
+    p.pos++; // ')' を消費
+    return result;
+  }
+
+  // 数値
+  return parseNumber(p);
+}
+
+function parseNumber(p: Parser): number {
+  const start = p.pos;
+  // 整数部
+  while (p.pos < p.input.length && /\d/.test(p.input[p.pos])) {
+    p.pos++;
+  }
+  // 小数部
+  if (p.pos < p.input.length && p.input[p.pos] === '.') {
+    p.pos++;
+    while (p.pos < p.input.length && /\d/.test(p.input[p.pos])) {
+      p.pos++;
+    }
+  }
+  if (p.pos === start) {
+    throw new Error(`計算式の形式が正しくありません (位置: ${p.pos})`);
+  }
+  return parseFloat(p.input.slice(start, p.pos));
+}

--- a/front/src/lib/tools/get-current-datetime.ts
+++ b/front/src/lib/tools/get-current-datetime.ts
@@ -1,0 +1,71 @@
+import { Tool } from './types';
+
+export const getCurrentDatetimeTool: Tool = {
+  definition: {
+    name: 'get_current_datetime',
+    description: '現在の日付と時刻を取得する',
+    parameters: {
+      type: 'object',
+      properties: {
+        timezone: {
+          type: 'string',
+          description: 'タイムゾーン (例: Asia/Tokyo, UTC)',
+        },
+      },
+      required: [],
+    },
+  },
+  execute: async (args) => {
+    const timezone =
+      typeof args.timezone === 'string' ? args.timezone : 'Asia/Tokyo';
+
+    try {
+      // ISO 8601 形式でタイムゾーン付き日時を生成
+      const now = new Date();
+      const formatter = new Intl.DateTimeFormat('sv-SE', {
+        timeZone: timezone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+      });
+
+      // sv-SE ロケールは YYYY-MM-DD HH:mm:ss 形式を返す
+      const parts = formatter.formatToParts(now);
+      const get = (type: string) =>
+        parts.find((p) => p.type === type)?.value ?? '00';
+
+      const dateStr = `${get('year')}-${get('month')}-${get('day')}T${get('hour')}:${get('minute')}:${get('second')}`;
+
+      // タイムゾーンオフセットを取得
+      const utcOffset = getUtcOffset(now, timezone);
+
+      return `${dateStr}${utcOffset}`;
+    } catch {
+      // 不正なタイムゾーン指定時は UTC で返す
+      return new Date().toISOString();
+    }
+  },
+};
+
+function getUtcOffset(date: Date, timezone: string): string {
+  try {
+    // UTC と指定タイムゾーンの差分を計算
+    const utcDate = new Date(date.toLocaleString('en-US', { timeZone: 'UTC' }));
+    const tzDate = new Date(date.toLocaleString('en-US', { timeZone: timezone }));
+    const diffMs = tzDate.getTime() - utcDate.getTime();
+    const diffMin = Math.round(diffMs / 60000);
+
+    const sign = diffMin >= 0 ? '+' : '-';
+    const absMin = Math.abs(diffMin);
+    const hours = String(Math.floor(absMin / 60)).padStart(2, '0');
+    const minutes = String(absMin % 60).padStart(2, '0');
+
+    return `${sign}${hours}:${minutes}`;
+  } catch {
+    return '+00:00';
+  }
+}

--- a/front/src/lib/tools/index.ts
+++ b/front/src/lib/tools/index.ts
@@ -1,0 +1,37 @@
+import { Tool, OllamaToolDefinition } from './types';
+
+const toolRegistry = new Map<string, Tool>();
+
+export function registerTool(tool: Tool): void {
+  toolRegistry.set(tool.definition.name, tool);
+}
+
+export function getTool(name: string): Tool | undefined {
+  return toolRegistry.get(name);
+}
+
+export function getAllToolDefinitions(): OllamaToolDefinition[] {
+  return Array.from(toolRegistry.values()).map((tool) => ({
+    type: 'function' as const,
+    function: {
+      name: tool.definition.name,
+      description: tool.definition.description,
+      parameters: tool.definition.parameters,
+    },
+  }));
+}
+
+export async function executeTool(
+  name: string,
+  args: Record<string, unknown>
+): Promise<string> {
+  const tool = toolRegistry.get(name);
+  if (!tool) {
+    throw new Error(`Unknown tool: "${name}"`);
+  }
+  return tool.execute(args);
+}
+
+export function getRegisteredToolNames(): string[] {
+  return Array.from(toolRegistry.keys());
+}

--- a/front/src/lib/tools/index.ts
+++ b/front/src/lib/tools/index.ts
@@ -32,6 +32,3 @@ export async function executeTool(
   return tool.execute(args);
 }
 
-export function getRegisteredToolNames(): string[] {
-  return Array.from(toolRegistry.keys());
-}

--- a/front/src/lib/tools/registry.ts
+++ b/front/src/lib/tools/registry.ts
@@ -1,0 +1,18 @@
+/**
+ * ツール登録の初期化モジュール。
+ * ここで全ツールを一度だけ登録する。
+ * /api/chat と /api/tools の両方からこのモジュールを import することで
+ * 重複登録を防ぐ（Map.set は冪等だが、管理ポイントを1箇所に集約する）。
+ */
+import { registerTool } from './index';
+import { getCurrentDatetimeTool } from './get-current-datetime';
+import { calculateTool } from './calculate';
+
+let initialized = false;
+
+export function initializeTools(): void {
+  if (initialized) return;
+  initialized = true;
+  registerTool(getCurrentDatetimeTool);
+  registerTool(calculateTool);
+}

--- a/front/src/lib/tools/types.ts
+++ b/front/src/lib/tools/types.ts
@@ -1,0 +1,70 @@
+// Ollama API 向けツール定義
+export interface OllamaToolDefinition {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: {
+      type: 'object';
+      properties: Record<
+        string,
+        {
+          type: string;
+          description: string;
+          enum?: string[];
+        }
+      >;
+      required: string[];
+    };
+  };
+}
+
+// Ollama レスポンスのツール呼び出し
+export interface OllamaToolCall {
+  function: {
+    name: string;
+    arguments: Record<string, unknown>;
+  };
+}
+
+// ツール実行記録（DB の metadata.toolCalls に保存）
+export interface ToolCallRecord {
+  name: string;
+  arguments: Record<string, unknown>;
+  result: string;
+  isError: boolean;
+  durationMs: number;
+}
+
+// クライアント向けストリーミングイベント（NDJSON 形式）
+export type AgentStreamEvent =
+  | { type: 'text_delta'; content: string }
+  | { type: 'tool_call_start'; name: string; arguments: Record<string, unknown> }
+  | { type: 'tool_call_result'; name: string; result: string; isError: boolean }
+  | { type: 'done'; metadata?: { toolCalls: ToolCallRecord[] } }
+  | { type: 'error'; message: string }
+  | { type: 'thinking'; content: string }; // Phase C
+
+// ツール定義インターフェース
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  parameters: {
+    type: 'object';
+    properties: Record<
+      string,
+      {
+        type: string;
+        description: string;
+        enum?: string[];
+      }
+    >;
+    required: string[];
+  };
+}
+
+// ツール実装インターフェース
+export interface Tool {
+  definition: ToolDefinition;
+  execute: (args: Record<string, unknown>) => Promise<string>;
+}

--- a/front/src/types/index.ts
+++ b/front/src/types/index.ts
@@ -1,8 +1,19 @@
+export interface ToolCallInfo {
+  name: string;
+  arguments: Record<string, unknown>;
+  result: string;
+  isError: boolean;
+  durationMs: number;
+}
+
 export interface Message {
   id: string;
   role: 'user' | 'assistant';
   content: string;
   createdAt: Date;
+  metadata?: {
+    toolCalls?: ToolCallInfo[];
+  } | null;
 }
 
 export interface Conversation {

--- a/front/tests/e2e/agent.spec.ts
+++ b/front/tests/e2e/agent.spec.ts
@@ -1,0 +1,277 @@
+import { test, expect } from '@playwright/test';
+import { cleanupAllConversations, sendMessage } from './helpers/test-data';
+
+// エージェント設定のON/OFFを切り替えるヘルパー
+async function openSettings(page: Parameters<typeof sendMessage>[0]) {
+  // 設定ボタンはサイドバー下部の歯車アイコン
+  const settingsButton = page.locator('button[aria-label="設定を開く"]');
+  await settingsButton.click();
+  await expect(page.getByRole('dialog', { name: '設定' })).toBeVisible({
+    timeout: 5000,
+  });
+}
+
+async function closeSettings(page: Parameters<typeof sendMessage>[0]) {
+  await page.getByRole('button', { name: 'Close' }).click();
+  await expect(page.getByRole('dialog', { name: '設定' })).toBeHidden({
+    timeout: 3000,
+  });
+}
+
+async function enableAgentTools(page: Parameters<typeof sendMessage>[0]) {
+  await openSettings(page);
+  const toggle = page.getByRole('button', { name: /ツール使用を有効化/ });
+  // 現在 OFF の場合のみクリック
+  const isEnabled = await page
+    .locator('[data-tools-enabled="true"]')
+    .count()
+    .then((c) => c > 0)
+    .catch(() => false);
+  if (!isEnabled) {
+    await toggle.click();
+  }
+  await closeSettings(page);
+}
+
+test.describe('エージェント機能', () => {
+  test.setTimeout(180000);
+
+  test.beforeAll(async ({ request }) => {
+    await cleanupAllConversations(request);
+  });
+
+  test.afterAll(async ({ request }) => {
+    await cleanupAllConversations(request);
+  });
+
+  test.describe('正常系', () => {
+    test('設定モーダルにAgent Toolsセクションが表示される', async ({ page }) => {
+      await page.goto('/');
+      await openSettings(page);
+
+      await expect(page.getByText('Agent Tools')).toBeVisible();
+      await expect(page.getByText('ツール使用を有効化')).toBeVisible();
+
+      await closeSettings(page);
+    });
+
+    test('Agent Toolsトグルで有効化・無効化できる', async ({ page }) => {
+      await page.goto('/');
+      await openSettings(page);
+
+      const toggle = page.getByRole('button', { name: /ツール使用を有効化/ });
+      await expect(toggle).toBeVisible();
+
+      // 1回クリックして状態が変化することを確認
+      const beforeClass = await toggle.getAttribute('class');
+      await toggle.click();
+      const afterClass = await toggle.getAttribute('class');
+      expect(beforeClass).not.toBe(afterClass);
+
+      // 元に戻す
+      await toggle.click();
+
+      await closeSettings(page);
+    });
+
+    test('Agent Tools設定がlocalStorageに保存される', async ({ page }) => {
+      await page.goto('/');
+      await openSettings(page);
+
+      const toggle = page.getByRole('button', { name: /ツール使用を有効化/ });
+      // ONにする
+      await toggle.click();
+      await closeSettings(page);
+
+      const stored = await page.evaluate(() =>
+        localStorage.getItem('agent-tools-enabled')
+      );
+      expect(stored).toBe('true');
+
+      // OFFに戻す
+      await openSettings(page);
+      await toggle.click();
+      await closeSettings(page);
+
+      const storedOff = await page.evaluate(() =>
+        localStorage.getItem('agent-tools-enabled')
+      );
+      expect(storedOff).toBe('false');
+    });
+
+    test('ページリロード後もAgent Tools設定が保持される', async ({ page }) => {
+      await page.goto('/');
+      // localStorage に直接 true をセット
+      await page.evaluate(() =>
+        localStorage.setItem('agent-tools-enabled', 'true')
+      );
+      await page.reload();
+
+      // 設定モーダルを開いてトグルがON状態であることを確認
+      await openSettings(page);
+      const toggle = page.getByRole('button', { name: /ツール使用を有効化/ });
+      // ONのときは nord-frost-1 の背景クラスが付く
+      await expect(toggle).toHaveClass(/nord-frost-1/);
+
+      // クリーンアップ
+      await toggle.click();
+      await closeSettings(page);
+    });
+
+    test('GET /api/tools がツール一覧を返す', async ({ request }) => {
+      const res = await request.get('http://localhost:3000/api/tools');
+      expect(res.status()).toBe(200);
+
+      const data = await res.json();
+      expect(data).toHaveProperty('tools');
+      expect(Array.isArray(data.tools)).toBe(true);
+      expect(data.tools.length).toBeGreaterThan(0);
+
+      const toolNames = data.tools.map((t: { name: string }) => t.name);
+      expect(toolNames).toContain('get_current_datetime');
+      expect(toolNames).toContain('calculate');
+    });
+
+    test('エージェントモードでメッセージを送信するとAI応答が返る', async ({
+      page,
+    }) => {
+      test.skip(
+        !!process.env.CI,
+        'CI環境ではエージェントのツール呼び出しがモデルに依存するためスキップ'
+      );
+
+      await page.goto('/');
+      await enableAgentTools(page);
+
+      await sendMessage(page, '今の日時を教えてください');
+
+      // ユーザーメッセージ表示を確認
+      await expect(
+        page.getByText('今の日時を教えてください').first()
+      ).toBeVisible({ timeout: 10000 });
+
+      // AI応答バブルが表示される
+      const aiMessage = page.locator('[class*="bg-nord-2"]').first();
+      await expect(aiMessage).toBeVisible({ timeout: 120000 });
+    });
+
+    test('エージェントモードでツール呼び出し完了後に結果が表示される', async ({
+      page,
+    }) => {
+      test.skip(
+        !!process.env.CI,
+        'CI環境ではエージェントのツール呼び出しがモデルに依存するためスキップ'
+      );
+
+      await page.goto('/');
+      await enableAgentTools(page);
+
+      await sendMessage(page, '今の日時を教えてください');
+
+      // 送信完了まで待機（ボタンが再度有効化）
+      const sendButton = page.locator('button[type="submit"]');
+      await expect(sendButton).toBeEnabled({ timeout: 120000 });
+
+      // ツール呼び出し完了インジケーター（✅）が表示される
+      const toolResult = page.locator('text=✅').first();
+      await expect(toolResult).toBeVisible({ timeout: 5000 });
+    });
+
+    test('ツール呼び出し結果は折りたたみ/展開できる', async ({ page }) => {
+      test.skip(
+        !!process.env.CI,
+        'CI環境ではエージェントのツール呼び出しがモデルに依存するためスキップ'
+      );
+
+      await page.goto('/');
+      await enableAgentTools(page);
+
+      await sendMessage(page, '今の日時を教えてください');
+
+      // 送信完了まで待機
+      const sendButton = page.locator('button[type="submit"]');
+      await expect(sendButton).toBeEnabled({ timeout: 120000 });
+
+      // ✅ ボタンをクリックして展開
+      const toolResultButton = page
+        .locator('button', { hasText: '✅' })
+        .first();
+      await expect(toolResultButton).toBeVisible({ timeout: 5000 });
+      await toolResultButton.click();
+
+      // 展開後に「結果」ラベルが表示される
+      await expect(page.getByText('結果').first()).toBeVisible({
+        timeout: 3000,
+      });
+
+      // 再クリックで折りたたむ
+      await toolResultButton.click();
+      await expect(page.getByText('結果').first()).toBeHidden({
+        timeout: 3000,
+      });
+    });
+  });
+
+  test.describe('準正常系', () => {
+    test('エージェントモードOFFでは通常チャットとして動作する', async ({
+      page,
+    }) => {
+      await page.goto('/');
+      // localStorage をクリアして Tools OFF 状態を確認
+      await page.evaluate(() =>
+        localStorage.setItem('agent-tools-enabled', 'false')
+      );
+      await page.reload();
+
+      await openSettings(page);
+      const toggle = page.getByRole('button', { name: /ツール使用を有効化/ });
+      // OFFのときは nord-frost-1 クラスが付かない
+      const cls = await toggle.getAttribute('class');
+      expect(cls).not.toMatch(/nord-frost-1/);
+      await closeSettings(page);
+    });
+
+    test('GET /api/tools のツールに enabled フィールドがある', async ({
+      request,
+    }) => {
+      const res = await request.get('http://localhost:3000/api/tools');
+      const data = await res.json();
+
+      for (const tool of data.tools as { name: string; description: string; enabled: boolean }[]) {
+        expect(typeof tool.name).toBe('string');
+        expect(typeof tool.description).toBe('string');
+        expect(typeof tool.enabled).toBe('boolean');
+      }
+    });
+  });
+
+  test.describe('異常系', () => {
+    test('POST /api/chat に enableTools=true で不正なメッセージを送ると400を返す', async ({
+      request,
+    }) => {
+      const res = await request.post('http://localhost:3000/api/chat', {
+        data: {
+          message: '',
+          conversationHistory: [],
+          model: 'qwen3-coder:latest',
+          enableTools: true,
+        },
+      });
+      expect(res.status()).toBe(400);
+    });
+
+    test('POST /api/chat に enableTools=true で10001文字のメッセージを送ると400を返す', async ({
+      request,
+    }) => {
+      const res = await request.post('http://localhost:3000/api/chat', {
+        data: {
+          message: 'あ'.repeat(10001),
+          conversationHistory: [],
+          model: 'qwen3-coder:latest',
+          enableTools: true,
+        },
+      });
+      expect(res.status()).toBe(400);
+    });
+  });
+});


### PR DESCRIPTION
## 概要

エージェント機能 Phase A（ツール呼び出し基盤）の実装。Ollama の Tool Calling API を活用し、AIが自律的にツールを使いながら応答を返せる仕組みを構築した。

## 変更内容

### バックエンド

| タスク | 内容 |
|--------|------|
| 21-1-1 | 型定義・ツールレジストリ (`src/lib/tools/types.ts`, `index.ts`) |
| 21-1-2 | 基本ツール実装 (`get_current_datetime`, `calculate`) |
| 21-1-3 | Ollama Tool Calling API 対応 (`ollama.ts` 拡張) |
| 21-1-4 | エージェントループ実装 (`agent.ts` — MAX_TOOL_ROUNDS=10) |
| 21-1-5 | `/api/chat` エージェントモード対応 + `/api/tools` 追加 |
| 21-1-6 | DB: `Message.metadata` (JSONB) カラム追加 |

### フロントエンド

| タスク | 内容 |
|--------|------|
| 21-1-7 | `ToolCallIndicator` / `ToolCallResult` コンポーネント、`ChatWindow` 統合、`useChat` NDJSON 対応 |
| 21-1-8 | `SettingsModal` Agent Tools トグル + localStorage 永続化 |
| 21-1-9 | E2E テスト (`agent.spec.ts`) |

## アーキテクチャのポイント

- **NDJSON イベントストリーム**: `application/x-ndjson` で `text_delta` / `tool_call_start` / `tool_call_result` / `done` / `error` イベントを送信
- **後方互換性**: `Content-Type` ヘッダーで通常チャット（plain text）とエージェントモードを判別
- **安全な計算**: `calculate` ツールは再帰降下パーサー実装（`eval()` 不使用）
- **無限ループ防止**: `MAX_TOOL_ROUNDS = 10`、`AGENT_TOOL_TIMEOUT_MS = 30000`

## テスト計画

- [ ] 設定モーダルに Agent Tools セクションが表示される
- [ ] トグル ON/OFF で localStorage に保存・ページリロードで保持
- [ ] `GET /api/tools` がツール一覧（name / description / enabled）を返す
- [ ] 空メッセージ・10001文字で 400 エラー
- [ ] （ローカル実行のみ）ツール呼び出し完了後に ✅ が表示・折りたたみ展開

🤖 Generated with [Claude Code](https://claude.com/claude-code)