### PR TITLE
feat: 待機中アニメーション追加 + PostgreSQLポート5499統一

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ cd front && pnpm prisma generate        # Prismaクライアント再生成
 |--------|------|-----------|
 | `OLLAMA_BASE_URL` | Ollama API接続先 | `http://localhost:11434` |
 | `OLLAMA_MODEL` | 使用モデル | `qwen3-coder:latest` |
-| `DATABASE_URL` | PostgreSQL接続文字列 | `postgresql://postgres:postgres@localhost:5432/chat_db` |
+| `DATABASE_URL` | PostgreSQL接続文字列 | `postgresql://postgres:postgres@localhost:5499/chat_db` |
 | `AGENT_MAX_TOOL_ROUNDS` | エージェントループの最大ラウンド数 | `10` |
 | `AGENT_TOOL_TIMEOUT_MS` | ツール実行タイムアウト（ms） | `30000` |
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ pnpm dev                   # 開発サーバー起動
 ```env
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=qwen3-coder:latest
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/chat_db
+DATABASE_URL=postgresql://postgres:postgres@localhost:5499/chat_db
 ```
 
 ## コマンド一覧

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: chat_db
     ports:
-      - '5432:5432'
+      - '5499:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -203,7 +203,7 @@ model Message {
 |--------|------|-------------|
 | `OLLAMA_BASE_URL` | Ollama APIの接続先 | `http://localhost:11434` |
 | `OLLAMA_MODEL` | 使用するモデル名 | `qwen3-coder:latest` |
-| `DATABASE_URL` | PostgreSQL接続文字列 | `postgresql://postgres:postgres@localhost:5432/chat_db` |
+| `DATABASE_URL` | PostgreSQL接続文字列 | `postgresql://postgres:postgres@localhost:5499/chat_db` |
 
 ## 状態管理
 

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -139,7 +139,7 @@ export default function Home() {
           selectedModel={selectedModel}
           onModelChange={setSelectedModel}
         />
-        <ChatWindow messages={messages} activeToolCall={activeToolCall} />
+        <ChatWindow messages={messages} activeToolCall={activeToolCall} isLoading={isLoading} />
         {error && (
           <div className="px-4 md:px-8 py-2 bg-nord-aurora-red/20 text-nord-aurora-red text-sm text-center">
             {error}

--- a/front/src/features/chat/components/ChatWindow.tsx
+++ b/front/src/features/chat/components/ChatWindow.tsx
@@ -11,9 +11,10 @@ import { AgentThinking } from './AgentThinking';
 interface ChatWindowProps {
   messages: Message[];
   activeToolCall?: { name: string; arguments: Record<string, unknown> } | null;
+  isLoading?: boolean;
 }
 
-export default function ChatWindow({ messages, activeToolCall }: ChatWindowProps) {
+export default function ChatWindow({ messages, activeToolCall, isLoading }: ChatWindowProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -21,6 +22,11 @@ export default function ChatWindow({ messages, activeToolCall }: ChatWindowProps
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
   }, [messages]);
+
+  // 最後のメッセージが assistant かつ content が空 = 最初のチャンク待ち
+  const lastMsg = messages[messages.length - 1];
+  const isWaitingFirstChunk =
+    isLoading && lastMsg?.role === 'assistant' && lastMsg.content === '';
 
   return (
     <div
@@ -41,82 +47,99 @@ export default function ChatWindow({ messages, activeToolCall }: ChatWindowProps
         </div>
       ) : (
         <>
-        {messages.map((msg) => (
-          <div
-            key={msg.id}
-            className={`flex flex-col max-w-[85%] md:max-w-[70%] ${
-              msg.role === 'user' ? 'ml-auto' : 'mr-auto'
-            }`}
-          >
+        {messages.map((msg) => {
+          const isThisWaiting = isWaitingFirstChunk && msg.id === lastMsg.id;
+
+          return (
             <div
-              className={`p-5 md:p-6 ${
-                msg.role === 'user'
-                  ? 'bg-nord-frost-2 text-nord-0 rounded-xl ml-auto font-medium shadow-lg shadow-black/10'
-                  : 'bg-nord-2 text-nord-6 rounded-xl mr-auto border border-nord-3'
+              key={msg.id}
+              className={`flex flex-col max-w-[85%] md:max-w-[70%] ${
+                msg.role === 'user' ? 'ml-auto' : 'mr-auto'
               }`}
             >
-              <div className="flex items-start gap-4">
-                {msg.role === 'assistant' && (
-                  <Bot size={22} className="shrink-0 mt-1 text-nord-frost-1" />
-                )}
-                {msg.role === 'assistant' ? (
-                  <MarkdownContent content={msg.content} />
-                ) : (
-                  <div className="whitespace-pre-wrap leading-relaxed text-sm md:text-base">
-                    {msg.content}
-                  </div>
-                )}
-                {msg.role === 'user' && (
-                  <User size={22} className="shrink-0 mt-1 text-nord-0" />
-                )}
+              <div
+                className={`p-5 md:p-6 ${
+                  msg.role === 'user'
+                    ? 'bg-nord-frost-2 text-nord-0 rounded-xl ml-auto font-medium shadow-lg shadow-black/10'
+                    : 'bg-nord-2 text-nord-6 rounded-xl mr-auto border border-nord-3'
+                }`}
+              >
+                <div className="flex items-start gap-4">
+                  {msg.role === 'assistant' && (
+                    <Bot
+                      size={22}
+                      className={`shrink-0 mt-1 text-nord-frost-1 ${isThisWaiting ? 'animate-pulse' : ''}`}
+                    />
+                  )}
+                  {msg.role === 'assistant' ? (
+                    isThisWaiting ? (
+                      // 最初のチャンク待ちドットアニメーション
+                      <div className="flex items-center gap-1.5 py-1" aria-label="応答を生成中">
+                        <span className="w-2 h-2 rounded-full bg-nord-frost-1 animate-bounce [animation-delay:0ms]" />
+                        <span className="w-2 h-2 rounded-full bg-nord-frost-1 animate-bounce [animation-delay:150ms]" />
+                        <span className="w-2 h-2 rounded-full bg-nord-frost-1 animate-bounce [animation-delay:300ms]" />
+                      </div>
+                    ) : (
+                      <MarkdownContent content={msg.content} />
+                    )
+                  ) : (
+                    <div className="whitespace-pre-wrap leading-relaxed text-sm md:text-base">
+                      {msg.content}
+                    </div>
+                  )}
+                  {msg.role === 'user' && (
+                    <User size={22} className="shrink-0 mt-1 text-nord-0" />
+                  )}
+                </div>
               </div>
-            </div>
 
-            {msg.role === 'assistant' && msg.metadata?.thinkingText && (
-              <AgentThinking content={msg.metadata.thinkingText} />
-            )}
-
-            {msg.role === 'assistant' && msg.metadata?.toolCalls && msg.metadata.toolCalls.length > 0 && (
-              <div className="mt-2 space-y-1">
-                {msg.metadata.toolCalls.map((tc, i) => (
-                  <ToolCallResult key={i} toolCall={tc} />
-                ))}
-              </div>
-            )}
-
-            {msg.role === 'assistant' && (msg.metadata?.agentRounds ?? 0) > 0 && (
-              <div className="mt-1 flex gap-3 text-xs text-[var(--color-nord-4)] opacity-40">
-                <span>{msg.metadata!.agentRounds} ラウンド</span>
-                {msg.metadata!.agentDurationMs !== undefined && (
-                  <span>{(msg.metadata!.agentDurationMs / 1000).toFixed(1)}s</span>
-                )}
-              </div>
-            )}
-
-            <div
-              className={`flex items-center gap-4 mt-3 px-2 text-xs text-nord-4/60 ${
-                msg.role === 'user' ? 'justify-end' : 'justify-start'
-              }`}
-            >
-              {msg.role === 'assistant' && (
-                // TODO: クリップボードコピー機能は Phase A 外。Phase B で実装予定
-                <button
-                  className="hover:text-nord-frost-1 transition-colors"
-                  onClick={() => navigator.clipboard.writeText(msg.content)}
-                  aria-label="コピー"
-                >
-                  <Copy size={14} />
-                </button>
+              {msg.role === 'assistant' && msg.metadata?.thinkingText && (
+                <AgentThinking content={msg.metadata.thinkingText} />
               )}
-              <span className="opacity-50 font-mono">
-                {msg.createdAt.toLocaleTimeString([], {
-                  hour: '2-digit',
-                  minute: '2-digit',
-                })}
-              </span>
+
+              {msg.role === 'assistant' && msg.metadata?.toolCalls && msg.metadata.toolCalls.length > 0 && (
+                <div className="mt-2 space-y-1">
+                  {msg.metadata.toolCalls.map((tc, i) => (
+                    <ToolCallResult key={i} toolCall={tc} />
+                  ))}
+                </div>
+              )}
+
+              {msg.role === 'assistant' && (msg.metadata?.agentRounds ?? 0) > 0 && (
+                <div className="mt-1 flex gap-3 text-xs text-[var(--color-nord-4)] opacity-40">
+                  <span>{msg.metadata!.agentRounds} ラウンド</span>
+                  {msg.metadata!.agentDurationMs !== undefined && (
+                    <span>{(msg.metadata!.agentDurationMs / 1000).toFixed(1)}s</span>
+                  )}
+                </div>
+              )}
+
+              {!isThisWaiting && (
+                <div
+                  className={`flex items-center gap-4 mt-3 px-2 text-xs text-nord-4/60 ${
+                    msg.role === 'user' ? 'justify-end' : 'justify-start'
+                  }`}
+                >
+                  {msg.role === 'assistant' && (
+                    <button
+                      className="hover:text-nord-frost-1 transition-colors"
+                      onClick={() => navigator.clipboard.writeText(msg.content)}
+                      aria-label="コピー"
+                    >
+                      <Copy size={14} />
+                    </button>
+                  )}
+                  <span className="opacity-50 font-mono">
+                    {msg.createdAt.toLocaleTimeString([], {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </span>
+                </div>
+              )}
             </div>
-          </div>
-        ))}
+          );
+        })}
         {activeToolCall && (
           <div className="mr-auto max-w-[85%] md:max-w-[70%]">
             <ToolCallIndicator name={activeToolCall.name} arguments={activeToolCall.arguments} />

--- a/front/tests/e2e/chat-loading.spec.ts
+++ b/front/tests/e2e/chat-loading.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { cleanupAllConversations, sendMessage } from './helpers/test-data';
+
+test.describe('ローディングアニメーション', () => {
+  test.setTimeout(120000);
+
+  test.beforeAll(async ({ request }) => {
+    await cleanupAllConversations(request);
+  });
+
+  test.afterAll(async ({ request }) => {
+    await cleanupAllConversations(request);
+  });
+
+  test.describe('正常系', () => {
+    test('メッセージ送信後にローディングアニメーションが表示される', async ({
+      page,
+    }) => {
+      await page.goto('/');
+
+      // メッセージを送信（応答を待たない）
+      await sendMessage(page, 'こんにちは');
+
+      // ローディングアニメーション（ドットバウンス）が表示されることを確認
+      const loadingIndicator = page.getByLabel('応答を生成中');
+      await expect(loadingIndicator).toBeVisible({ timeout: 10000 });
+    });
+
+    test('AI応答完了後にローディングアニメーションが消える', async ({
+      page,
+    }) => {
+      await page.goto('/');
+      await sendMessage(page, 'はい');
+
+      // アニメーションが一時的に表示される
+      const loadingIndicator = page.getByLabel('応答を生成中');
+      await expect(loadingIndicator).toBeVisible({ timeout: 10000 });
+
+      // 応答完了後にアニメーションが消え、AI応答テキストが表示される
+      await expect(loadingIndicator).not.toBeVisible({ timeout: 90000 });
+      const aiMessages = page.locator('[class*="bg-nord-2"]');
+      await expect(aiMessages.first()).toBeVisible();
+    });
+  });
+
+  test.describe('準正常系', () => {
+    test('ローディング中はコピーボタンが表示されない', async ({ page }) => {
+      await page.goto('/');
+      await sendMessage(page, 'テスト');
+
+      const loadingIndicator = page.getByLabel('応答を生成中');
+      await expect(loadingIndicator).toBeVisible({ timeout: 10000 });
+
+      // ローディング中はコピーボタンが表示されない（isThisWaiting=true の場合に非表示）
+      const copyButton = page.locator('button[aria-label="コピー"]').last();
+      await expect(copyButton).not.toBeVisible();
+    });
+  });
+
+  test.describe('異常系', () => {
+    test('ウェルカム画面ではローディングアニメーションが表示されない', async ({
+      request,
+      page,
+    }) => {
+      await cleanupAllConversations(request);
+      await page.goto('/');
+
+      // 会話がない状態ではウェルカム画面が表示され、アニメーションは表示されない
+      await expect(page.getByText('Nordic Chat へようこそ')).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(page.getByLabel('応答を生成中')).not.toBeVisible();
+    });
+  });
+});

--- a/manuals/setup-guide-macos.md
+++ b/manuals/setup-guide-macos.md
@@ -223,7 +223,7 @@ docker compose ps
 
 ```
 NAME       IMAGE         STATUS         PORTS
-chat_db    postgres:16   Up ...         0.0.0.0:5432->5432/tcp
+chat_db    postgres:16   Up ...         0.0.0.0:5499->5432/tcp
 ```
 
 ---
@@ -244,7 +244,7 @@ pnpm install
 cat <<'EOF' > .env.local
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=qwen3-coder:latest
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/chat_db
+DATABASE_URL=postgresql://postgres:postgres@localhost:5499/chat_db
 EOF
 ```
 
@@ -349,7 +349,7 @@ ollama serve
 ### PostgreSQL に接続できない
 
 ```
-Can't reach database server at `localhost:5432`
+Can't reach database server at `localhost:5499`
 ```
 
 **対処法:**
@@ -362,7 +362,7 @@ docker compose ps
 docker compose up -d
 
 # ポートが別プロセスに使用されていないか確認
-lsof -i :5432
+lsof -i :5499
 ```
 
 ### pnpm install でエラーが出る


### PR DESCRIPTION
## Summary

- AI応答待機中（最初のチャンク到着前）にドットバウンスアニメーションと Bot アイコンパルスを表示
- PostgreSQL ホストポートを `5432` → `5499` に変更（ローカル PostgreSQL との競合回避）
- 全ドキュメント（CLAUDE.md / README.md / docs / manuals）のポート記載を `5499` に統一
- ローディングアニメーションの E2E テスト追加（`chat-loading.spec.ts`）

## Test plan

- [ ] `docker compose up -d` で PostgreSQL が `5499` ポートで起動することを確認
- [ ] `front/.env.local` の `DATABASE_URL` が `localhost:5499` であることを確認
- [ ] メッセージ送信後にドットバウンスアニメーションが表示されることを確認
- [ ] AI応答完了後にアニメーションが消え、テキストが表示されることを確認
- [ ] `pnpm test:e2e tests/e2e/chat-loading.spec.ts` が通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)