### PR TITLE
docs(rules): JSDoc（TSDoc）規約を追加

### DIFF
--- a/.claude/rules/jsdoc.md
+++ b/.claude/rules/jsdoc.md
@@ -1,0 +1,59 @@
+---
+description: JSDoc（TSDoc）ドキュメンテーションコメント規約 — TypeScript の公開シンボルに必須
+globs: front/src/**
+---
+
+# JSDoc 規約（TypeScript）
+
+TypeScript コードの**公開シンボル**には JSDoc（TSDoc 記法）を**必須**とする。TypeDoc によるドキュメント生成を前提とする。
+
+## 必須対象（公開シンボル）
+
+以下の公開シンボルには JSDoc を必ず付与する:
+
+- `export` された関数・クラス・メソッド・型（`type` / `interface`）・定数
+- React/Vue コンポーネントの **props 型**（各プロパティに説明）
+- カスタムフック（`useXxx`）・composable（`useXxx`）
+- 公開 API のハンドラー・サービスメソッド
+
+**任意対象**: `export` されない内部関数、および処理が自明な 1 行ユーティリティ。ただし意図が非自明なものは内部でも付与する。
+
+## 混乱テスト（公開/内部・本番/テストを問わない）
+
+判断軸は「public か否か」ではなく **「1 か月後の自分／他プロジェクト帰りの読み手が『これは何？なぜ？』となるか」**。なるなら、内部関数でもテストコードでも "why" を残す。
+
+- **キャスト・回避策には "why" 必須**: `as unknown as` / `as any` / `@ts-ignore` / `@ts-expect-error` / マジック値 / 複雑な正規表現 / 明示的なワークアラウンド。**型を欺く・仕様を迂回する箇所は、その根拠（なぜ安全か／なぜ必要か）がコードから消える**ため、コメントが唯一の記録になる。
+  - 例: テストダブルを `repo as unknown as Repository<Task>` で注入する場合、「ダブルは対象が実際に呼ぶメソッドだけの部分実装で、実型は構造的に大きいため二段キャストで隙間を埋める（実行時は使う分だけで足りる）」と残す。
+- **テスト足場**（SUT ビルダー・複雑な fixture・非自明な mock）も、意図が読み取りにくいなら付ける。
+
+## 記述ルール
+
+- **型は書かない**: 型は TypeScript のシグネチャが唯一の真実（source of truth）。JSDoc に `{string}` 等の型ブレースを併記しない（二重管理・型ずれの原因になる）。JSDoc は**意図・意味・制約**を日本語で記述する。
+- **要約行必須**: 1 行目にそのシンボルが「何をするか」を簡潔に書く。
+- **`@param` 必須**: 全引数に `@param name - 説明` を記述する。オプション引数・デフォルト値の意味も明記する。
+- **`@returns` 必須**: 戻り値がある場合は `@returns 説明` を記述する（`void` / JSX 返却のコンポーネントは省略可）。
+- **`@throws` 必須**: 意図的に例外を投げる場合は `@throws {ErrorType} 発生条件` を記述する。
+- **補助タグ（任意）**: `@example` `@deprecated` `@see` は必要に応じて使う。
+
+## 例
+
+```ts
+/**
+ * ユーザー ID から表示名を解決する。キャッシュに無ければ API を叩く。
+ *
+ * @param userId - 対象ユーザーの UUID
+ * @param opts - 解決オプション（`force` 指定でキャッシュを無視）
+ * @returns 表示名。ユーザーが存在しない場合は `null`
+ * @throws {ApiError} API 通信に失敗した場合
+ */
+export async function resolveDisplayName(
+  userId: string,
+  opts?: { force?: boolean },
+): Promise<string | null> {
+  // ...
+}
+```
+
+## Lint による強制（推奨）
+
+`eslint-plugin-jsdoc` を導入し、公開シンボルへの JSDoc 欠落・`@param` / `@returns` 漏れを CI で検出する。TypeScript プロジェクトでは型ブレース系ルールを無効化する（`jsdoc/require-param-type` / `jsdoc/require-returns-type` を off）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,7 @@ DBスキーマ詳細は `.claude/rules/database.md` を参照。
 | ファイル | スコープ | 内容 |
 |---------|---------|------|
 | `coding-standards.md` | 全体 | TypeScript strict / pnpm / ESLint+Prettier / シークレット禁止 |
+| `jsdoc.md` | `front/src/**` | JSDoc（TSDoc）規約・公開シンボルに必須・型ブレース禁止・キャスト/回避策に "why" |
 | `error-handling.md` | 全体 | バリデーション・HTTP ステータス・統一エラーレスポンス方針 |
 | `security.md` | 全体 | XSS 対策・SQL インジェクション禁止・CSP・シークレット管理 |
 | `testing.md` | `front/tests/**` | E2E テスト方針・3分類必須・Playwright 設定 |


### PR DESCRIPTION
## 概要

`/rules-update` スキルの実行結果として、TypeScript 公開シンボルへの JSDoc（TSDoc）規約を追加します。既存の8ルールファイルはプロジェクト固有のカスタマイズ済み内容を保持するため変更していません（唯一の不足分である jsdoc.md のみ追加）。

## 変更点

- `.claude/rules/jsdoc.md` を新規追加
  - TypeScript の公開シンボル（`export` 関数・型・props・カスタムフック等）に JSDoc 必須
  - 型ブレース禁止（型は TS シグネチャが source of truth）
  - キャスト・回避策（`as any` / `@ts-ignore` 等）には "why" コメント必須
  - glob 対象: `front/src/**`
- `CLAUDE.md` の `## Rules` テーブルに `jsdoc.md` の行を追加

## レビュー確認事項

- JSDoc を「公開シンボルに必須」とする規約の強度が、個人開発の運用感に合っているか
- `eslint-plugin-jsdoc` による Lint 強制は**本PRには含めていません**（規約上は推奨のみ）。CI 強制が必要なら別PRで対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)