### PR TITLE
fix(ci): Ollama を 0.30.7 に固定し LLM 依存 E2E にリトライ耐性を追加

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -60,7 +60,11 @@ jobs:
 
       - name: Setup Ollama
         run: |
-          curl -fsSL https://ollama.com/install.sh | sh
+          # install.sh は常に最新版を入れるが、新しい Ollama は CPU 推論で
+          # qwen2.5:0.5b が segfault（llama-server core dumped）し /api/chat が 5xx を返す。
+          # 最後に CI が通った 2026-06-10 時点の最新である 0.30.7 に固定する。
+          # 経緯は docs/08-ci-e2e-bug-report.md #13 参照。`latest` は破壊的に上がるため使わない。
+          curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.30.7 sh
           ollama serve &
           sleep 5
           ollama pull qwen2.5:0.5b

--- a/docs/08-ci-e2e-bug-report.md
+++ b/docs/08-ci-e2e-bug-report.md
@@ -1,6 +1,6 @@
 # CI E2Eテスト バグレポート
 
-> 最終更新: 2026-06-11
+> 最終更新: 2026-07-11
 
 ## 目次
 
@@ -17,6 +17,7 @@
 - [10. Shift+Enter テストでメッセージが送信される（1件）](#10-shiftenter-テストでメッセージが送信される1件)
 - [11. `overflow-y-auto` コンテナの可視性（1件）](#11-overflow-y-auto-コンテナの可視性1件)
 - [12. pnpm 11 系が Node 20 で起動失敗（ビルド前に全失敗）](#12-pnpm-11-系が-node-20-で起動失敗ビルド前に全失敗)
+- [13. Ollama 最新版が CPU 推論で segfault（2件）](#13-ollama-最新版が-cpu-推論で-segfault2件)
 - [CI スキップ対象テスト一覧](#ci-スキップ対象テスト一覧)
 - [今後の改善案](#今後の改善案)
 
@@ -214,6 +215,28 @@ Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
 **対応**: `pnpm/action-setup` の `version` を `latest` → `10` に固定。ローカル（pnpm 10.33.0）・lockfileVersion 9.0・Node 20 と整合する。`latest` は破壊的にメジャーが上がるため使用しない。
 
 **ファイル**: `.github/workflows/e2e-test.yml`
+
+---
+
+## 13. Ollama 最新版が CPU 推論で segfault（2件）
+
+**症状**: `agent-phase-c.spec.ts` の2テスト（`systemPrompt 付きで /api/chat POST しても 200 が返る` / `systemPrompt が極端に長くても API が正常に処理する`）が失敗。`/api/chat` が 200 ではなく 5xx を返す。WebServer ログに以下が多発:
+
+```
+[WebServer] Ollama connection error: Ollama API error (500):
+{"error":"llama-server process has terminated: signal: segmentation fault (core dumped)"}
+```
+
+**原因**: `Setup Ollama` ステップが `curl -fsSL https://ollama.com/install.sh | sh` で**常に最新の Ollama** を導入していた。最後に CI が通った 2026-06-10（当時の最新 = 0.30.7）以降にリリースされた新しい Ollama が、CI ランナー（CPU only）で `qwen2.5:0.5b` を実行すると `llama-server` プロセスが segfault するようになった。バリデーション系（400 期待）テストは Ollama に到達しないため影響を受けず、実際に生成を要する2テストのみ失敗した。
+
+**対応**:
+- **Ollama バージョン固定**: install.sh に `OLLAMA_VERSION=0.30.7` を渡し、最後に CI が通ったバージョンに固定（`latest` は破壊的に上がるため使わない）。
+  ```yaml
+  curl -fsSL https://ollama.com/install.sh | OLLAMA_VERSION=0.30.7 sh
+  ```
+- **リトライ耐性**: LLM 依存テストを `postChatWithRetry` ヘルパー経由に変更。5xx（Ollama バックエンド障害）のときのみ間隔を空けて再試行し、4xx（バリデーション）は即返す。断続的な segfault を吸収しつつ、恒久障害は正しく fail させる（握り潰さない）。
+
+**ファイル**: `.github/workflows/e2e-test.yml`, `front/tests/e2e/helpers/test-data.ts`, `front/tests/e2e/agent-phase-c.spec.ts`
 
 ---
 

--- a/front/tests/e2e/agent-phase-c.spec.ts
+++ b/front/tests/e2e/agent-phase-c.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { cleanupAllConversations } from './helpers/test-data';
+import { cleanupAllConversations, postChatWithRetry } from './helpers/test-data';
 
 const BASE_URL = 'http://localhost:3000';
 
@@ -158,13 +158,12 @@ test.describe('エージェント Phase C — 自律エージェント化', () =
     });
 
     test('systemPrompt 付きで /api/chat POST しても 200 が返る', async ({ request }) => {
-      const res = await request.post(`${BASE_URL}/api/chat`, {
-        data: {
-          message: 'こんにちは',
-          conversationHistory: [],
-          enableTools: false,
-          systemPrompt: 'あなたは親切なアシスタントです。',
-        },
+      // Ollama の一時的な segfault（CI/CPU）を吸収するためリトライ付きで送信する
+      const res = await postChatWithRetry(request, {
+        message: 'こんにちは',
+        conversationHistory: [],
+        enableTools: false,
+        systemPrompt: 'あなたは親切なアシスタントです。',
       });
       expect(res.status()).toBe(200);
     });
@@ -172,13 +171,12 @@ test.describe('エージェント Phase C — 自律エージェント化', () =
 
   test.describe('異常系', () => {
     test('systemPrompt が極端に長くても API が正常に処理する', async ({ request }) => {
-      const res = await request.post(`${BASE_URL}/api/chat`, {
-        data: {
-          message: 'こんにちは',
-          conversationHistory: [],
-          enableTools: false,
-          systemPrompt: 'あ'.repeat(5000),
-        },
+      // Ollama の一時的な segfault（CI/CPU）を吸収するためリトライ付きで送信する
+      const res = await postChatWithRetry(request, {
+        message: 'こんにちは',
+        conversationHistory: [],
+        enableTools: false,
+        systemPrompt: 'あ'.repeat(5000),
       });
       // メッセージは valid なので 200 が返ること
       expect(res.status()).toBe(200);

--- a/front/tests/e2e/helpers/test-data.ts
+++ b/front/tests/e2e/helpers/test-data.ts
@@ -1,4 +1,4 @@
-import { APIRequestContext, Page } from '@playwright/test';
+import { APIRequestContext, APIResponse, Page } from '@playwright/test';
 
 const BASE_URL = 'http://localhost:3000';
 
@@ -108,6 +108,38 @@ export async function fetchMessages(
   );
   const data = await res.json();
   return data.messages;
+}
+
+/**
+ * `/api/chat` に POST し、Ollama バックエンドの一時的な障害をリトライで吸収するヘルパー。
+ *
+ * CI ランナー（CPU only）では llama-server が segfault して Route Handler が 5xx を
+ * 返すことがある。この障害は再起動で回復し得るため、5xx のときのみ間隔を空けて再試行する。
+ * バリデーション由来の 4xx はテストの検証対象そのものなので即座に返す（リトライしない）。
+ * 全試行が 5xx なら最後のレスポンスを返すため、Ollama が本当に死んでいればテストは
+ * 正しく失敗する（バックエンド障害を握り潰さない）。
+ *
+ * @param request - Playwright の APIRequestContext
+ * @param data - `/api/chat` へ送るリクエストボディ
+ * @param maxAttempts - 最大試行回数（デフォルト 3）
+ * @returns 最後に受け取った APIResponse（4xx なら初回のもの）
+ */
+export async function postChatWithRetry(
+  request: APIRequestContext,
+  data: Record<string, unknown>,
+  maxAttempts = 3
+): Promise<APIResponse> {
+  let res!: APIResponse;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    res = await request.post(`${BASE_URL}/api/chat`, { data });
+    // 5xx（Ollama バックエンド障害）以外は確定結果として即返す
+    if (res.status() < 500) return res;
+    if (attempt < maxAttempts) {
+      // llama-server の再起動を待ってから再試行
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+  }
+  return res;
 }
 
 export async function cleanupAllConversations(


### PR DESCRIPTION
## 背景

`docs/add-jsdoc-rule`（PR #41）の E2E が失敗していた。調査の結果、原因は **PR のコードではなく CI 環境**だった。

- `Setup Ollama` が `install.sh | sh` で**常に最新の Ollama** を導入していた
- 最後に CI が通った 2026-06-10（当時最新 = 0.30.7）以降の Ollama が、CI ランナー（CPU only）で `qwen2.5:0.5b` を実行すると `llama-server` が **segfault**
- その結果 `/api/chat` が 5xx を返し、`agent-phase-c.spec.ts` の2テスト（`:160`/`:174`）が失敗（バリデーション系は Ollama に到達せず全パス）

```
[WebServer] Ollama connection error: Ollama API error (500):
{"error":"llama-server process has terminated: signal: segmentation fault (core dumped)"}
```

> 再実行では旧コミットが success になったため、この segfault は**断続的な flake** と確認済み。恒久リリース不良を将来踏んだ場合に備え、本 PR で二重に固める。

## 変更内容

| ファイル | 変更 |
|---|---|
| `.github/workflows/e2e-test.yml` | Ollama を `OLLAMA_VERSION=0.30.7`（最後に通った版）に固定 |
| `front/tests/e2e/helpers/test-data.ts` | `postChatWithRetry` 追加（**5xx のみ再試行・4xx は即返し・全滅時は正しく fail**） |
| `front/tests/e2e/agent-phase-c.spec.ts` | 該当2テストをリトライ版に置換 |
| `docs/08-ci-e2e-bug-report.md` | 項目 #13 追記・目次/最終更新日を更新 |

## 設計意図

- **バージョン固定**が真の恒久対策。リトライは「再起動で回復する断続 segfault」への保険で、両輪で守る。
- `postChatWithRetry` は 4xx（バリデーション）をリトライしないため、`400 を返す`系テストの意味を壊さない。全試行 5xx なら本物のバックエンド障害として **fail させる**（握り潰さない）。

## ドキュメント乖離チェック

- CI 変更 → `docs/08-ci-e2e-bug-report.md` を同一 PR 内で更新済み（影響マップ準拠）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)