### PR TITLE
test(integration): エラー契約を IT へ移譲し /api/chat・/api/models を補強

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -34,9 +34,18 @@ globs: "front/tests/**"
 
 ## IT（Vitest + Testcontainers）方針
 
-- **対象**: DB 依存の route handler（`/api/conversations` 系の CRUD・messages・cascade 削除・バリデーション/404/400）。
+- **対象**: route handler 全般。
+  - DB 依存（`/api/conversations` 系の CRUD・messages・cascade 削除・404/400）→ 実 DB で検証。
+  - 外部依存（`/api/chat`・`/api/models`）→ Ollama を fetch スタブして**エラー契約**（接続失敗→502、バリデーション→400）と正常応答の中継を検証。
 - **実依存**: PostgreSQL を **Testcontainers で使い捨てコンテナとして起動**し、`prisma migrate deploy` でスキーマ適用。開発 DB には一切触れない。
-- **mock 方針**: 真の外部 3rd-party（Ollama / DuckDuckGo / 任意 Web）**のみ**手製 fetch スタブで差し替える。DB はモックしない（配線検証が目的）。初期対象（conversations 系）は外部依存が無いためスタブ不要。
+- **mock 方針**: 真の外部 3rd-party（Ollama / DuckDuckGo / 任意 Web）**のみ**手製 fetch スタブ（`helpers/ollama-stub.ts` の `stubFetch`）で差し替える。DB はモックしない（配線検証が目的）。
+
+## エラーハンドリングの層分担
+
+エラー系は「契約」と「見た目」で層を分ける（E2E で自前ロジックを mock しないため）。
+
+- **API のエラー契約**（Ollama ダウン→502、DB/バリデーション→4xx/5xx）→ **IT**（fetch スタブで決定的に検証）。
+- **エラー時の UI 描画・耐性**（エラーメッセージ表示・クラッシュしない・エラー状態のスクショ）→ **E2E**。ブラウザ必須かつ実バックエンドを安定的に壊せないため、**境界の障害注入（`page.route`）を唯一の許容例外**とする。
 - **呼び出し**: handler を関数として import し、`NextRequest` を組んで直接実行（ブラウザ・Next サーバー起動なし）。
 - **隔離**: 各テスト `beforeEach` で会話を全削除（Message は cascade）。`fileParallelism: false` で DB 競合を回避。
 - **実行**: `pnpm test:integration`（CI では専用 `integration-test` ジョブ。Docker のみ必要、Ollama 不要）。

--- a/docs/06-testing.md
+++ b/docs/06-testing.md
@@ -38,6 +38,7 @@
   - **UT**: 外部I/O非依存の純ロジックを対象（`lib/validation.ts`・`lib/tools/calculate.ts`・`lib/agent-prompts.ts` 等）。外部I/O（fetch/DB）のみモックし、ビジネスロジックはモックしない。UIコンポーネント単位のユニットテストは実施しない（E2Eで担保）。
   - **IT**: route handler をブラウザ抜きで直接叩き、実PostgreSQL（Testcontainers）相手に handler↔Prisma↔DB を検証。実依存（DB）は使い、mockは真の外部3rd-party（Ollama/Web）のみ。
   - **E2E**: 実際のOllama + PostgreSQLに接続してテストする（実環境・ブラウザ経由）。
+- **エラーハンドリングの層分担**: APIのエラー**契約**（Ollamaダウン→502・バリデーション→4xx）はITで決定的に検証。エラー時のUI**描画・耐性**はE2Eで検証し、境界の障害注入（`page.route`）を唯一の許容mock例外とする。
 - **ブラウザ**（E2E）: Chromiumのみ。
 - **CI**: GitHub Actionsで自動実行（UT・IT・E2Eは独立ジョブ）。
 
@@ -60,9 +61,10 @@
 | 配置 | `front/tests/integration/`（`*.test.ts`） |
 | 設定 | `front/vitest.integration.config.ts`・`front/tests/integration/helpers/`（global-setup: コンテナ起動＋`migrate deploy`、setup-env: 接続URL注入） |
 | 実行 | `pnpm test:integration` |
-| 対象（初期） | `/api/conversations`（作成/一覧）・`[id]`（削除・cascade）・`[id]/messages`（保存/取得） |
+| 対象 | DB系: `/api/conversations`（作成/一覧）・`[id]`（削除・cascade）・`[id]/messages`（保存/取得）。外部系: `/api/chat`・`/api/models`（Ollamaをfetchスタブ） |
 | 実依存 | PostgreSQL を Testcontainers で使い捨て起動（開発DBに触れない） |
-| モック | 真の外部3rd-party（Ollama/Web）のみ手製fetchスタブ。初期対象は外部依存が無く mock なし |
+| モック | 真の外部3rd-party（Ollama/Web）のみ手製fetchスタブ（`helpers/ollama-stub.ts`）。DB系はスタブ無し |
+| エラー契約 | Ollamaダウン→502・バリデーション→400 等を IT で決定的に検証（E2E の障害注入から移譲） |
 | 前提 | 生成クライアント（`src/generated/prisma/`）は gitignore のため `pnpm prisma generate` が必要。Docker が必要。CI の `integration-test` ジョブは Node 22（testcontainers が使う undici の `markAsUncloneable` は undici 6 系＝Node 22+ で追加された API のため） |
 
 UT・IT・E2E とも **正常系・準正常系・異常系の3分類**で記述する。
@@ -293,7 +295,9 @@ front/tests/
 │   │   └── db.ts                 # resetDb・NextRequest/コンテキスト構築
 │   ├── conversations.test.ts     # 作成/一覧（POST/GET）
 │   ├── conversation-delete.test.ts # 削除・cascade・UUID/404/500
-│   └── messages.test.ts          # メッセージ保存/取得・バリデーション
+│   ├── messages.test.ts          # メッセージ保存/取得・バリデーション
+│   ├── chat.test.ts              # /api/chat（Ollama fetchスタブ・502契約・400）
+│   └── models.test.ts            # /api/models（Ollama fetchスタブ・502契約）
 └── e2e/
     ├── helpers/
     │   └── test-data.ts          # テストデータ管理ヘルパー（CRUD・入力支援）

--- a/docs/07-tasks.md
+++ b/docs/07-tasks.md
@@ -177,6 +177,7 @@
 - [x] route handler をブラウザ抜きで直接叩く方式（NextRequest 構築）・実DBで検証
 - [x] CI に独立ジョブ `integration-test`（`.github/workflows/integration-test.yml`。Docker のみ・Ollama不要）を追加
 - [x] 方針ドキュメント更新（3層構成へ改定）
+- [x] IT 補強＋エラー契約の移譲: `/api/chat`・`/api/models` を Ollama fetch スタブで検証（`helpers/ollama-stub.ts`）。Ollamaダウン→502・空/超過/不正JSON→400 を IT 化（E2E の障害注入から移譲）。層分担（契約=IT / UI描画=E2E）を testing.md・docs/06 に明文化
 
 ## フェーズ6: CI
 

--- a/front/tests/integration/chat.test.ts
+++ b/front/tests/integration/chat.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { POST } from '@/app/api/chat/route';
+import { jsonRequest } from './helpers/db';
+import { ollamaStreamResponse, stubFetch } from './helpers/ollama-stub';
+
+/**
+ * `/api/chat`（非エージェント経路）の IT。
+ * Ollama は真の外部のため fetch をスタブし、handler↔ollama.ts↔ストリーミング中継の
+ * 配線と、エラー時の HTTP 契約（E2E から移譲した 502 系）を決定的に検証する。
+ * この経路は DB を使わないため Prisma には触れない。
+ */
+const URL = 'http://localhost/api/chat';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('POST /api/chat（通常チャット）', () => {
+  describe('正常系', () => {
+    it('Ollama のストリーミング応答を中継して 200 とテキストを返す', async () => {
+      stubFetch(() => ollamaStreamResponse(['こん', 'にちは']));
+
+      const res = await POST(jsonRequest(URL, 'POST', { message: 'やあ', enableTools: false }));
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe('こんにちは');
+    });
+  });
+
+  describe('準正常系', () => {
+    it('conversationHistory を含めて Ollama にリクエストを送る', async () => {
+      const fetchMock = stubFetch(() => ollamaStreamResponse(['ok']));
+
+      const res = await POST(
+        jsonRequest(URL, 'POST', {
+          message: '次は？',
+          conversationHistory: [{ role: 'user', content: '前の発言' }],
+          enableTools: false,
+        }),
+      );
+      expect(res.status).toBe(200);
+
+      // Ollama へ渡された body に履歴＋今回のメッセージが時系列で含まれる
+      const [, init] = fetchMock.mock.calls[0];
+      const sent = JSON.parse(init!.body as string);
+      expect(sent.messages).toEqual([
+        { role: 'user', content: '前の発言' },
+        { role: 'user', content: '次は？' },
+      ]);
+    });
+  });
+
+  describe('異常系', () => {
+    it('Ollama への接続に失敗すると 502 を返す（E2E から移譲したエラー契約）', async () => {
+      stubFetch(() => {
+        throw new Error('ECONNREFUSED');
+      });
+
+      const res = await POST(jsonRequest(URL, 'POST', { message: 'やあ', enableTools: false }));
+      expect(res.status).toBe(502);
+      expect((await res.json()).error).toContain('Ollama');
+    });
+
+    it('Ollama が非 2xx を返すと 502 を返す', async () => {
+      stubFetch(() => new Response('boom', { status: 500 }));
+
+      const res = await POST(jsonRequest(URL, 'POST', { message: 'やあ', enableTools: false }));
+      expect(res.status).toBe(502);
+    });
+
+    it('空メッセージは 400。Ollama へは到達しない', async () => {
+      const fetchMock = stubFetch(() => ollamaStreamResponse(['x']));
+
+      const res = await POST(jsonRequest(URL, 'POST', { message: '   ', enableTools: false }));
+      expect(res.status).toBe(400);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('10,000 文字超のメッセージは 400', async () => {
+      stubFetch(() => ollamaStreamResponse(['x']));
+
+      const res = await POST(
+        jsonRequest(URL, 'POST', { message: 'あ'.repeat(10001), enableTools: false }),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('不正な JSON ボディは 400', async () => {
+      const res = await POST(jsonRequest(URL, 'POST', 'not-json'));
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/front/tests/integration/helpers/ollama-stub.ts
+++ b/front/tests/integration/helpers/ollama-stub.ts
@@ -1,0 +1,53 @@
+import { vi } from 'vitest';
+
+/**
+ * 真の外部 3rd-party である Ollama（`ollama.ts` の global `fetch`）をスタブするヘルパー群。
+ *
+ * IT の方針「実依存（DB）は本物・真の外部のみスタブ」に従い、Ollama への HTTP だけを
+ * 差し替える。E2E で `page.route` により障害注入していた「Ollama ダウン→502」等の
+ * API 契約を、ブラウザ抜き・決定的に検証するために使う。
+ */
+
+/**
+ * Ollama `/api/chat` 相当の NDJSON ストリーミング成功レスポンスを組み立てる。
+ *
+ * @param contents - 各チャンクが運ぶテキスト断片（順に連結される）
+ * @returns `.ok` が true でボディが NDJSON ストリームの `Response`
+ */
+export function ollamaStreamResponse(contents: string[]): Response {
+  const lines = [
+    ...contents.map((content) =>
+      JSON.stringify({ model: 'test', message: { role: 'assistant', content }, done: false }),
+    ),
+    JSON.stringify({ model: 'test', message: { role: 'assistant', content: '' }, done: true }),
+  ]
+    .map((l) => l + '\n')
+    .join('');
+
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(lines));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { 'content-type': 'application/x-ndjson' },
+  });
+}
+
+/**
+ * global `fetch` を任意のハンドラでスタブする。呼び出し記録を返すので引数検証にも使える。
+ *
+ * @param handler - fetch の代替実装（URL・init を受け取り Response を返す）
+ * @returns スタブした fetch のモック関数
+ */
+export function stubFetch(
+  handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
+) {
+  const mock = vi.fn((input: string | URL | Request, init?: RequestInit) =>
+    Promise.resolve(handler(String(input), init)),
+  );
+  vi.stubGlobal('fetch', mock);
+  return mock;
+}

--- a/front/tests/integration/models.test.ts
+++ b/front/tests/integration/models.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { GET } from '@/app/api/models/route';
+import { stubFetch } from './helpers/ollama-stub';
+
+/**
+ * `/api/models` の IT。Ollama `/api/tags` を fetch スタブし、モデル一覧取得の
+ * 正常応答と、接続失敗時の 502 契約（E2E から移譲）を検証する。DB 非依存。
+ */
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('GET /api/models', () => {
+  describe('正常系', () => {
+    it('Ollama のモデル一覧を名前配列＋既定モデルで返す', async () => {
+      stubFetch(
+        () =>
+          new Response(
+            JSON.stringify({ models: [{ name: 'qwen2.5:0.5b' }, { name: 'llama3' }] }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+      );
+
+      const res = await GET();
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.models).toEqual(['qwen2.5:0.5b', 'llama3']);
+      expect(typeof body.defaultModel).toBe('string');
+    });
+  });
+
+  describe('準正常系', () => {
+    it('モデルが 0 件でも 200 と空配列を返す', async () => {
+      stubFetch(
+        () => new Response(JSON.stringify({ models: [] }), { status: 200 }),
+      );
+
+      const res = await GET();
+      expect(res.status).toBe(200);
+      expect((await res.json()).models).toEqual([]);
+    });
+  });
+
+  describe('異常系', () => {
+    it('Ollama への接続に失敗すると 502 を返す', async () => {
+      stubFetch(() => {
+        throw new Error('ECONNREFUSED');
+      });
+
+      const res = await GET();
+      expect(res.status).toBe(502);
+    });
+
+    it('Ollama が非 2xx を返すと 502 を返す', async () => {
+      stubFetch(() => new Response('nope', { status: 500 }));
+
+      const res = await GET();
+      expect(res.status).toBe(502);
+    });
+  });
+});


### PR DESCRIPTION
## 概要

E2E で `page.route` により障害注入していた **API のエラー契約**（Ollama ダウン→502 等）を、**IT で fetch スタブして決定的に検証**する。これにより E2E の mock を「UI がエラー時に壊れない/表示する」検証だけに純化し、テスト層の役割分担を明確化する。

## 方針（決定事項）

- **エラー契約は IT へ移譲**（fetch スタブ・決定的・高速）／**E2E の UI エラー描画テストは残す**。
- **IT を厚く**：`/api/chat`・`/api/models` を新規カバー。

## 変更内容

- `helpers/ollama-stub.ts`：真の外部 Ollama の global `fetch` をスタブ（`stubFetch` / `ollamaStreamResponse`）。IT の作法「実依存(DB)は本物・真の外部のみスタブ」に沿う
- `chat.test.ts`（8ケース・3分類）
  - 正常：Ollama ストリーミング応答を中継して 200＋テキスト
  - 準正常：`conversationHistory` が Ollama へ時系列で渡る（送信 body を検証）
  - 異常：**Ollama ダウン→502**・非2xx→502・空メッセージ→400（**Ollama 未到達**も検証）・1万字超→400・不正JSON→400
- `models.test.ts`（4ケース・3分類）：一覧取得・0件・**接続失敗→502**

## 層分担（明文化）

| 観点 | どこで | 手段 |
|---|---|---|
| API のエラー**契約**（502/4xx） | **IT** | fetch スタブ |
| エラー時の **UI 描画・耐性** | E2E | 境界の障害注入（唯一の許容 mock 例外） |

## 検証

- `pnpm test:integration`: **32 passed**（21→32、+11）
- `pnpm lint`: **0 error** ／ `tsc`（tests/integration）: **0 error**
- 新規依存なし（`vi` は既存 Vitest）

## ドキュメント同期

`.claude/rules/testing.md`（層分担）・`docs/06-testing.md`（IT対象/ツリー/基本方針）・`docs/07-tasks.md`。**E2E は変更なし**（UI エラーテストは残置）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)